### PR TITLE
Fix app crash when unsupported appId is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quest | Fixed multiple entries of same test results on quest patient detail screen
 - Quest | Fixed mislabeling of questionnaire responses on quest patient detail screen
 - Quest | Fix patient registration with estimated age/dob
+- Engine | Fixed app crash when wrong appId is provided
 
 ### Changed
 - EIR | Updated overdue trigger flow for Vaccine Due date

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/appsetting/AppSettingActivity.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/appsetting/AppSettingActivity.kt
@@ -51,9 +51,15 @@ class AppSettingActivity : AppCompatActivity() {
           configurationRegistry.loadAppConfigurations(
             appId = applicationId,
             accountAuthenticator = accountAuthenticator
-          ) {
-            sharedPreferencesHelper.write(APP_ID_CONFIG, applicationId)
-            finish()
+          ) { loadSuccessful: Boolean ->
+            if (loadSuccessful) {
+              sharedPreferencesHelper.write(APP_ID_CONFIG, applicationId)
+              finish()
+            } else {
+              showToast(
+                getString(R.string.application_not_supported, appSettingViewModel.appId.value)
+              )
+            }
           }
         } else if (loadConfigs != null && !loadConfigs)
           showToast(getString(R.string.application_not_supported, appSettingViewModel.appId.value))

--- a/android/engine/src/main/res/values/strings.xml
+++ b/android/engine/src/main/res/values/strings.xml
@@ -89,6 +89,6 @@
     <string name="replace_photo">Replace photo</string>
     <string name="take_photo">Take photo</string>
     <string name="edit">Edit</string>
-    <string name="application_not_supported">Application %1$s is not supported</string>
+    <string name="application_not_supported">Application %1$s not found</string>
     <string name="eCBIS_app_name">eCBIS</string>
 </resources>

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/appsetting/AppSettingActivityTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/appsetting/AppSettingActivityTest.kt
@@ -18,6 +18,7 @@ package org.smartregister.fhircore.engine.ui.appsetting
 
 import android.app.Activity
 import android.content.Context
+import android.widget.Toast
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -28,6 +29,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.robolectric.Robolectric
+import org.robolectric.shadows.ShadowToast
 import org.smartregister.fhircore.engine.R
 import org.smartregister.fhircore.engine.configuration.app.ApplicationConfiguration
 import org.smartregister.fhircore.engine.robolectric.ActivityRobolectricTest
@@ -68,6 +70,16 @@ class AppSettingActivityTest : ActivityRobolectricTest() {
     Assert.assertEquals("AppTheme", applicationConfiguration.theme)
     Assert.assertTrue(applicationConfiguration.languages.containsAll(listOf("en", "sw")))
     Assert.assertTrue(appSettingActivity.isFinishing)
+  }
+
+  @Test
+  fun testThatConfigsAreNotLoadedAndToastNotificationDisplayed() {
+    appSettingActivity.appSettingViewModel.run {
+      onApplicationIdChanged("fakeAppId")
+      loadConfigurations(true)
+    }
+    val latestToast = ShadowToast.getLatestToast()
+    Assert.assertEquals(Toast.LENGTH_LONG, latestToast.duration)
   }
 
   override fun getActivity(): Activity = appSettingActivity


### PR DESCRIPTION
Signed-off-by: Elly Kitoto <junkmailstoelly@gmail.com>

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #921 and #923  

**Type**
Choose one: Bug fix

**Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [x] I have added any strings visible on UI components to the `strings.xml` file
- [x] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
