### PR TITLE
Only show patient identifier that has 'use'= 'official'

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDao.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDao.kt
@@ -40,7 +40,6 @@ import org.smartregister.fhircore.engine.util.extension.extractGeneralPractition
 import org.smartregister.fhircore.engine.util.extension.extractHealthStatusFromMeta
 import org.smartregister.fhircore.engine.util.extension.extractName
 import org.smartregister.fhircore.engine.util.extension.extractOfficialIdentifier
-import org.smartregister.fhircore.engine.util.extension.extractSecondaryIdentifier
 import org.smartregister.fhircore.engine.util.extension.extractTelecom
 import org.smartregister.fhircore.engine.util.extension.hasActivePregnancy
 import org.smartregister.fhircore.engine.util.extension.toAgeDisplay
@@ -61,8 +60,7 @@ constructor(
 
   fun hivPatientIdentifier(patient: Patient): String =
     // would either be an ART or HCC number
-    patient.extractOfficialIdentifier()
-      ?: patient.extractSecondaryIdentifier() ?: patient.identifierFirstRep.value ?: ""
+    patient.extractOfficialIdentifier() ?: ""
 
   override suspend fun loadRegisterData(
     currentPage: Int,

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDaoTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDaoTest.kt
@@ -195,7 +195,7 @@ class HivRegisterDaoTest : RobolectricTest() {
   }
 
   @Test
-  fun `test hiv patient identifier to be the 'secondary' identifier when no 'official' identifier found`() =
+  fun `test hiv patient identifier to be empty string when no 'official' identifier found`() =
       runTest {
     val identifierNumber = "149856"
     val patient =
@@ -209,7 +209,7 @@ class HivRegisterDaoTest : RobolectricTest() {
           }
         )
       }
-    assertEquals(identifierNumber, hivRegisterDao.hivPatientIdentifier(patient))
+    assertEquals("", hivRegisterDao.hivPatientIdentifier(patient))
   }
 
   @Test


### PR DESCRIPTION
Fixes #1475

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
