### PR TITLE
[MWCore] Show appropriate message on timeout during log in

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/Exceptions.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/Exceptions.kt
@@ -16,6 +16,6 @@
 
 package org.smartregister.fhircore.engine.ui.login
 
-class InvalidCredentialsException(cause: Throwable) : Exception("Invalid login credentials", cause)
+class InvalidCredentialsException(cause: Throwable? = null) : Exception("Invalid login credentials", cause)
 
-class LoginNetworkException(cause: Throwable) : Exception("Network call failed", cause)
+class LoginNetworkException(cause: Throwable? = null) : Exception("Network call failed", cause)

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/Exceptions.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/Exceptions.kt
@@ -16,6 +16,7 @@
 
 package org.smartregister.fhircore.engine.ui.login
 
-class InvalidCredentialsException(cause: Throwable? = null) : Exception("Invalid login credentials", cause)
+class InvalidCredentialsException(cause: Throwable? = null) :
+  Exception("Invalid login credentials", cause)
 
 class LoginNetworkException(cause: Throwable? = null) : Exception("Network call failed", cause)

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/Exceptions.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/Exceptions.kt
@@ -16,8 +16,6 @@
 
 package org.smartregister.fhircore.engine.ui.login
 
-enum class LoginErrorState {
-  UNKNOWN_HOST,
-  NETWORK_ERROR,
-  INVALID_CREDENTIALS
-}
+class InvalidCredentialsException(cause: Throwable) : Exception("Invalid login credentials", cause)
+
+class LoginNetworkException(cause: Throwable) : Exception("Network call failed", cause)

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginScreen.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginScreen.kt
@@ -256,7 +256,7 @@ fun LoginPage(
           color = MaterialTheme.colors.error,
           text =
             when (loginErrorState) {
-              LoginErrorState.UNKNOWN_HOST ->
+              LoginErrorState.UNKNOWN_HOST, LoginErrorState.NETWORK_ERROR ->
                 stringResource(
                   id = R.string.login_error,
                   stringResource(R.string.login_call_fail_error_message)

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginViewModel.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginViewModel.kt
@@ -115,7 +115,14 @@ constructor(
     object : ResponseHandler<OAuthResponse> {
       override fun handleResponse(call: Call<OAuthResponse>, response: Response<OAuthResponse>) {
         if (!response.isSuccessful) {
-          handleFailure(call, IOException("Network call failed with $response"))
+          if (response.code() == 401) {
+            handleFailure(
+              call,
+              InvalidCredentialsException(Throwable(response.errorBody()?.toString()))
+            )
+          } else {
+            handleFailure(call, LoginNetworkException(Throwable(response.errorBody()?.toString())))
+          }
         } else {
           accountAuthenticator.run {
             addAuthenticatedAccount(
@@ -258,8 +265,12 @@ constructor(
   }
 
   private fun handleErrorMessage(throwable: Throwable) {
-    if (throwable is UnknownHostException) _loginErrorState.postValue(LoginErrorState.UNKNOWN_HOST)
-    else _loginErrorState.postValue(LoginErrorState.INVALID_CREDENTIALS)
+    when (throwable) {
+      is UnknownHostException -> _loginErrorState.postValue(LoginErrorState.UNKNOWN_HOST)
+      is InvalidCredentialsException ->
+        _loginErrorState.postValue(LoginErrorState.INVALID_CREDENTIALS)
+      else -> _loginErrorState.postValue(LoginErrorState.NETWORK_ERROR)
+    }
   }
 
   companion object {

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginViewModelTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginViewModelTest.kt
@@ -230,9 +230,16 @@ internal class LoginViewModelTest : RobolectricTest() {
     ReflectionHelpers.callInstanceMethod<Any>(
       loginViewModel,
       "handleErrorMessage",
-      ReflectionHelpers.ClassParameter(Throwable::class.java, IOException())
+      ReflectionHelpers.ClassParameter(Throwable::class.java, InvalidCredentialsException())
     )
     Assert.assertEquals(LoginErrorState.INVALID_CREDENTIALS, loginViewModel.loginErrorState.value)
+
+    ReflectionHelpers.callInstanceMethod<Any>(
+      loginViewModel,
+      "handleErrorMessage",
+      ReflectionHelpers.ClassParameter(Throwable::class.java, IOException())
+    )
+    Assert.assertEquals(LoginErrorState.NETWORK_ERROR, loginViewModel.loginErrorState.value)
   }
 
   @Test

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginViewModelTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginViewModelTest.kt
@@ -237,6 +237,13 @@ internal class LoginViewModelTest : RobolectricTest() {
     ReflectionHelpers.callInstanceMethod<Any>(
       loginViewModel,
       "handleErrorMessage",
+      ReflectionHelpers.ClassParameter(Throwable::class.java, LoginNetworkException())
+    )
+    Assert.assertEquals(LoginErrorState.NETWORK_ERROR, loginViewModel.loginErrorState.value)
+
+    ReflectionHelpers.callInstanceMethod<Any>(
+      loginViewModel,
+      "handleErrorMessage",
       ReflectionHelpers.ClassParameter(Throwable::class.java, IOException())
     )
     Assert.assertEquals(LoginErrorState.NETWORK_ERROR, loginViewModel.loginErrorState.value)


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

The login page was not showing the collect message when there is an error. It only shows the message that the username and password is incorrect

**Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
