### PR TITLE
[MWCore] Fix sync timestamp in navigation drawer

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModel.kt
@@ -132,7 +132,7 @@ constructor(
 
     val syncTimestampFormatter =
       SimpleDateFormat(SYNC_TIMESTAMP_INPUT_FORMAT, Locale.getDefault()).apply {
-        timeZone = TimeZone.getTimeZone(UTC)
+        timeZone = TimeZone.getDefault()
       }
     val parse: Date? = syncTimestampFormatter.parse(timestamp.toString())
     return if (parse == null) "" else simpleDateFormat.format(parse)
@@ -147,6 +147,5 @@ constructor(
   companion object {
     const val SYNC_TIMESTAMP_INPUT_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
     const val SYNC_TIMESTAMP_OUTPUT_FORMAT = "hh:mm aa, MMM d"
-    const val UTC = "UTC"
   }
 }


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

The last sync time stamp on the drawer shows 2 hours ahead of the local time

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
