### PR TITLE
[MWCore] - Pressing back should close the navigation drawer

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainScreen.kt
@@ -18,6 +18,7 @@
 
 package org.smartregister.fhircore.quest.ui.main
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ExperimentalMaterialApi
@@ -63,6 +64,10 @@ fun MainScreen(
     scope.launch {
       if (open) scaffoldState.drawerState.open() else scaffoldState.drawerState.close()
     }
+  }
+
+  BackHandler(enabled = scaffoldState.drawerState.isOpen) {
+    scope.launch { scaffoldState.drawerState.close() }
   }
 
   Scaffold(


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] 
On the main page, when the navigation drawer is opened and the user presses the back button, the app closes. Instead, the navigation drawer should close while the app remains open.

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
