### PR TITLE
Pass 'active' careplan as a single resource, not in bundle

### DIFF
--- a/android/anc/src/main/java/org/smartregister/fhircore/anc/ui/family/form/FamilyQuestionnaireActivity.kt
+++ b/android/anc/src/main/java/org/smartregister/fhircore/anc/ui/family/form/FamilyQuestionnaireActivity.kt
@@ -82,7 +82,10 @@ class FamilyQuestionnaireActivity : QuestionnaireActivity() {
     }
   }
 
-  override fun postSaveSuccessful(questionnaireResponse: QuestionnaireResponse, extras: List<Resource>?) {
+  override fun postSaveSuccessful(
+    questionnaireResponse: QuestionnaireResponse,
+    extras: List<Resource>?
+  ) {
     lifecycleScope.launch {
       val patientId = questionnaireResponse.subject.extractId()
 

--- a/android/eir/src/main/java/org/smartregister/fhircore/eir/ui/vaccine/RecordVaccineActivity.kt
+++ b/android/eir/src/main/java/org/smartregister/fhircore/eir/ui/vaccine/RecordVaccineActivity.kt
@@ -22,7 +22,12 @@ import androidx.lifecycle.lifecycleScope
 import ca.uhn.fhir.parser.IParser
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import org.hl7.fhir.r4.model.*
+import org.hl7.fhir.r4.model.DateTimeType
+import org.hl7.fhir.r4.model.Immunization
+import org.hl7.fhir.r4.model.PositiveIntType
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.Resource
 import org.smartregister.fhircore.eir.R
 import org.smartregister.fhircore.eir.data.model.PatientVaccineSummary
 import org.smartregister.fhircore.eir.ui.patient.details.nextDueDateFmt
@@ -77,7 +82,10 @@ class RecordVaccineActivity : QuestionnaireActivity() {
     }
   }
 
-  override fun postSaveSuccessful(questionnaireResponse: QuestionnaireResponse, extras: List<Resource>?) {
+  override fun postSaveSuccessful(
+    questionnaireResponse: QuestionnaireResponse,
+    extras: List<Resource>?
+  ) {
     val nextVaccineDate = savedImmunization.nextDueDateFmt()
     val currentDose = savedImmunization.protocolAppliedFirstRep.doseNumberPositiveIntType.value
 

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/models/PatientProfileViewData.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/models/PatientProfileViewData.kt
@@ -66,9 +66,9 @@ sealed class ProfileViewData(
     val guardiansRelatedPersonResource = guardians.filterIsInstance<RelatedPerson>()
 
     val populationResources: ArrayList<Resource> by lazy {
-      val resources = carePlans + conditions + guardiansRelatedPersonResource + observations
+      val resources = conditions + guardiansRelatedPersonResource + observations
       val resourcesAsBundle = Bundle().apply { resources.map { this.addEntry().resource = it } }
-      arrayListOf(resourcesAsBundle)
+      arrayListOf(*carePlans.toTypedArray(), resourcesAsBundle)
     }
   }
 


### PR DESCRIPTION
A patient is expected to only have One active careplan

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #1745

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
