### PR TITLE
[MWCORE] Stop Login Activity from going back to the previous Activity

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginActivity.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginActivity.kt
@@ -24,8 +24,6 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
-import android.window.OnBackInvokedCallback
-import android.window.OnBackInvokedDispatcher
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import dagger.Lazy
@@ -43,7 +41,6 @@ import org.smartregister.fhircore.engine.ui.theme.AppTheme
 import org.smartregister.fhircore.engine.util.FORCE_LOGIN_VIA_USERNAME
 import org.smartregister.fhircore.engine.util.FORCE_LOGIN_VIA_USERNAME_FROM_PIN_SETUP
 import org.smartregister.fhircore.engine.util.extension.showToast
-import timber.log.Timber
 
 @AndroidEntryPoint
 class LoginActivity :
@@ -143,14 +140,14 @@ class LoginActivity :
 
   override fun onBackPressed() {
     if (backPressed) {
-      finishAffinity();
+      finishAffinity()
       val a = Intent(Intent.ACTION_MAIN)
       a.addCategory(Intent.CATEGORY_HOME)
       a.flags = Intent.FLAG_ACTIVITY_NEW_TASK
       startActivity(a)
     }
 
-    backPressed = true;
+    backPressed = true
     Toast.makeText(this, getString(R.string.press_back_again), Toast.LENGTH_SHORT).show()
 
     Handler(Looper.getMainLooper()).postDelayed({ backPressed = false }, 2000)

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginActivity.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginActivity.kt
@@ -29,6 +29,7 @@ import androidx.activity.viewModels
 import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.system.exitProcess
 import org.smartregister.fhircore.engine.R
 import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry
 import org.smartregister.fhircore.engine.configuration.app.AppConfigClassification
@@ -141,15 +142,11 @@ class LoginActivity :
   override fun onBackPressed() {
     if (backPressed) {
       finishAffinity()
-      val a = Intent(Intent.ACTION_MAIN)
-      a.addCategory(Intent.CATEGORY_HOME)
-      a.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-      startActivity(a)
+      exitProcess(0)
+    } else {
+      backPressed = true
+      Toast.makeText(this, getString(R.string.press_back_again), Toast.LENGTH_SHORT).show()
+      Handler(Looper.getMainLooper()).postDelayed({ backPressed = false }, 3000)
     }
-
-    backPressed = true
-    Toast.makeText(this, getString(R.string.press_back_again), Toast.LENGTH_SHORT).show()
-
-    Handler(Looper.getMainLooper()).postDelayed({ backPressed = false }, 2000)
   }
 }

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginActivity.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginActivity.kt
@@ -21,7 +21,11 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.widget.Toast
+import android.window.OnBackInvokedCallback
+import android.window.OnBackInvokedDispatcher
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import dagger.Lazy
@@ -39,6 +43,7 @@ import org.smartregister.fhircore.engine.ui.theme.AppTheme
 import org.smartregister.fhircore.engine.util.FORCE_LOGIN_VIA_USERNAME
 import org.smartregister.fhircore.engine.util.FORCE_LOGIN_VIA_USERNAME_FROM_PIN_SETUP
 import org.smartregister.fhircore.engine.util.extension.showToast
+import timber.log.Timber
 
 @AndroidEntryPoint
 class LoginActivity :
@@ -51,6 +56,7 @@ class LoginActivity :
   @Inject lateinit var syncBroadcaster: Lazy<SyncBroadcaster>
 
   private val loginViewModel by viewModels<LoginViewModel>()
+  private var backPressed = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -133,5 +139,20 @@ class LoginActivity :
 
   private fun launchDialPad(phone: String) {
     startActivity(Intent(Intent.ACTION_DIAL).apply { data = Uri.parse(phone) })
+  }
+
+  override fun onBackPressed() {
+    if (backPressed) {
+      finishAffinity();
+      val a = Intent(Intent.ACTION_MAIN)
+      a.addCategory(Intent.CATEGORY_HOME)
+      a.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+      startActivity(a)
+    }
+
+    backPressed = true;
+    Toast.makeText(this, getString(R.string.press_back_again), Toast.LENGTH_SHORT).show()
+
+    Handler(Looper.getMainLooper()).postDelayed({ backPressed = false }, 2000)
   }
 }

--- a/android/engine/src/main/res/values/strings.xml
+++ b/android/engine/src/main/res/values/strings.xml
@@ -133,4 +133,5 @@
     <string name="service_card">SERVICE CARD</string>
     <string name="auth_token_expired">Session expired</string>
     <string name="identifier_unassigned">Unassigned</string>
+    <string name="press_back_again">Please click BACK again to exit</string>
 </resources>

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginActivityTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginActivityTest.kt
@@ -41,6 +41,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
 import org.robolectric.util.ReflectionHelpers
@@ -252,12 +253,16 @@ class LoginActivityTest : ActivityRobolectricTest() {
     Assert.assertNotNull(loginActivity.getApplicationConfiguration())
   }
 
-  @Test
+  @Test(expected = RuntimeException::class)
   fun testOnBackPressesTwoTimes() {
+    val runTime = spyk(Runtime.getRuntime())
+    ReflectionHelpers.setStaticField(Runtime::class.java, "currentRuntime", runTime)
+    every { runTime.exit(anyInt()) } returns Unit
     loginActivity.onBackPressed()
     assertTrue(ReflectionHelpers.getField(loginActivity, "backPressed"))
     loginActivity.onBackPressed()
     verify { loginActivity.finishAffinity() }
+    verify { runTime.exit(0) }
   }
 
   override fun getActivity(): Activity {

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginActivityTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginActivityTest.kt
@@ -35,6 +35,7 @@ import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
 import javax.inject.Inject
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Before
@@ -42,6 +43,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
+import org.robolectric.util.ReflectionHelpers
 import org.smartregister.fhircore.engine.R
 import org.smartregister.fhircore.engine.auth.AccountAuthenticator
 import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry
@@ -248,6 +250,14 @@ class LoginActivityTest : ActivityRobolectricTest() {
       }
     }
     Assert.assertNotNull(loginActivity.getApplicationConfiguration())
+  }
+
+  @Test
+  fun testOnBackPressesTwoTimes() {
+    loginActivity.onBackPressed()
+    assertTrue(ReflectionHelpers.getField(loginActivity, "backPressed"))
+    loginActivity.onBackPressed()
+    verify { loginActivity.finishAffinity() }
   }
 
   override fun getActivity(): Activity {


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] 

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
