### PR TITLE
pre-populate questionnaire items

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/model/ActionConfig.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/model/ActionConfig.kt
@@ -41,4 +41,11 @@ data class ActionConfig(
     }
 }
 
-@Serializable data class ActionParameter(val key: String, val value: String)
+@Serializable
+data class ActionParameter(
+  val key: String,
+  val paramType: ActionParameterType? = null,
+  val dataType: DataType? = null,
+  val value: String,
+  val linkId: String? = null
+) : java.io.Serializable

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/model/ActionParameterType.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/model/ActionParameterType.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.engine.domain.model
+
+import kotlinx.serialization.json.JsonNames
+
+/** Represents different types of parameters that can be defined within the config actions */
+enum class ActionParameterType {
+  /** Represents parameters that are used to pre-populate Questionnaire items with initial values */
+  @JsonNames("pre_populate", "PrePopulate") PREPOPULATE
+}

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/model/DataType.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/model/DataType.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.engine.domain.model
+
+/** Represents the set of possible set of data types that are used for the resource elements */
+enum class DataType {
+  BOOLEAN,
+  DECIMAL,
+  INTEGER,
+  DATE,
+  DATETIME,
+  TIME,
+  STRING,
+  URI,
+  CODING,
+  QUANTITY
+}

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireExtension.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireExtension.kt
@@ -20,10 +20,23 @@ import com.google.android.fhir.datacapture.common.datatype.asStringValue
 import com.google.android.fhir.datacapture.targetStructureMap
 import com.google.android.fhir.logicalId
 import java.util.Locale
+import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.DateTimeType
+import org.hl7.fhir.r4.model.DateType
+import org.hl7.fhir.r4.model.DecimalType
 import org.hl7.fhir.r4.model.IdType
+import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Quantity
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.StringType
+import org.hl7.fhir.r4.model.TimeType
+import org.hl7.fhir.r4.model.Type
+import org.hl7.fhir.r4.model.UriType
+import org.smartregister.fhircore.engine.domain.model.ActionParameter
+import org.smartregister.fhircore.engine.domain.model.DataType
 
 fun QuestionnaireResponse.QuestionnaireResponseItemComponent.asLabel() =
   this.linkId
@@ -118,5 +131,40 @@ fun List<Questionnaire.QuestionnaireItemComponent>.find(
     if (it.item.isNotEmpty()) {
       it.item.find(fieldType, value, target)
     }
+  }
+}
+
+/** Pre-Populate Questionnaire items with initial values */
+fun List<Questionnaire.QuestionnaireItemComponent>.prePopulateInitialValues(
+  prePopulationParams: List<ActionParameter>
+) {
+  forEach { item ->
+    prePopulationParams.firstOrNull { it.linkId == item.linkId }?.let { actionParam ->
+      item.initial =
+        arrayListOf<Questionnaire.QuestionnaireItemInitialComponent>(
+          Questionnaire.QuestionnaireItemInitialComponent().apply {
+            value = actionParam.dataType?.let { actionParam.value.castToType(it) }
+          }
+        )
+    }
+    if (item.item.isNotEmpty()) {
+      item.item.prePopulateInitialValues(prePopulationParams)
+    }
+  }
+}
+
+/** Cast string value (including json string) to the FHIR {@link org.hl7.fhir.r4.model.Type} */
+fun String.castToType(type: DataType): Type? {
+  return when (type) {
+    DataType.BOOLEAN -> BooleanType(this)
+    DataType.DECIMAL -> DecimalType(this)
+    DataType.INTEGER -> IntegerType(this)
+    DataType.DATE -> DateType(this)
+    DataType.DATETIME -> DateTimeType(this)
+    DataType.TIME -> TimeType(this)
+    DataType.STRING -> StringType(this)
+    DataType.URI -> UriType(this)
+    DataType.CODING -> this.tryDecodeJson<Coding>()
+    DataType.QUANTITY -> this.tryDecodeJson<Quantity>()
   }
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -49,6 +49,7 @@ import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry
 import org.smartregister.fhircore.engine.configuration.QuestionnaireConfig
 import org.smartregister.fhircore.engine.cql.LibraryEvaluator
 import org.smartregister.fhircore.engine.data.local.DefaultRepository
+import org.smartregister.fhircore.engine.domain.model.ActionParameter
 import org.smartregister.fhircore.engine.domain.model.QuestionnaireType
 import org.smartregister.fhircore.engine.task.FhirCarePlanGenerator
 import org.smartregister.fhircore.engine.util.DispatcherProvider
@@ -63,6 +64,7 @@ import org.smartregister.fhircore.engine.util.extension.find
 import org.smartregister.fhircore.engine.util.extension.findSubject
 import org.smartregister.fhircore.engine.util.extension.isExtractionCandidate
 import org.smartregister.fhircore.engine.util.extension.isIn
+import org.smartregister.fhircore.engine.util.extension.prePopulateInitialValues
 import org.smartregister.fhircore.engine.util.extension.prepareQuestionsForReadingOrEditing
 import org.smartregister.fhircore.engine.util.extension.referenceValue
 import org.smartregister.fhircore.engine.util.extension.retainMetadata
@@ -104,10 +106,18 @@ constructor(
       ?.extractLogicalIdUuid()
   }
 
-  suspend fun loadQuestionnaire(id: String, type: QuestionnaireType): Questionnaire? =
+  suspend fun loadQuestionnaire(
+    id: String,
+    type: QuestionnaireType,
+    prePopulationParams: List<ActionParameter>? = emptyList()
+  ): Questionnaire? =
     defaultRepository.loadResource<Questionnaire>(id)?.apply {
       if (type.isReadOnly() || type.isEditMode()) {
         item.prepareQuestionsForReadingOrEditing(QUESTIONNAIRE_RESPONSE_ITEM, type.isReadOnly())
+      }
+      // prepopulate questionnaireItems with initial values
+      if (prePopulationParams?.isNotEmpty() == true) {
+        item.prePopulateInitialValues(prePopulationParams)
       }
 
       // TODO https://github.com/opensrp/fhircore/issues/991#issuecomment-1027872061

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/extensions/ConfigExtensions.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/extensions/ConfigExtensions.kt
@@ -41,10 +41,8 @@ fun List<ActionConfig>.handleClickEvent(
         actionConfig.questionnaire?.let { questionnaireConfig ->
           navController.context.launchQuestionnaire<QuestionnaireActivity>(
             questionnaireConfig = questionnaireConfig,
-            intentBundle =
-              if (resourceData != null) actionConfig.paramsBundle(resourceData.computedValuesMap)
-              else bundleOf(),
-            computedValuesMap = resourceData?.computedValuesMap
+            computedValuesMap = resourceData?.computedValuesMap,
+            actionParams = actionConfig.params
           )
         }
       }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/extensions/QuestionnaireExtension.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/extensions/QuestionnaireExtension.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import org.smartregister.fhircore.engine.configuration.QuestionnaireConfig
+import org.smartregister.fhircore.engine.domain.model.ActionParameter
 import org.smartregister.fhircore.engine.util.extension.getActivity
 import org.smartregister.fhircore.quest.ui.questionnaire.QuestionnaireActivity
 import org.smartregister.fhircore.quest.ui.questionnaire.QuestionnaireActivity.Companion.intentArgs
@@ -28,13 +29,18 @@ import org.smartregister.fhircore.quest.ui.questionnaire.QuestionnaireActivity.C
 inline fun <reified Q : QuestionnaireActivity> Context.launchQuestionnaire(
   intentBundle: Bundle = bundleOf(),
   questionnaireConfig: QuestionnaireConfig? = null,
-  computedValuesMap: Map<String, Any>?
+  computedValuesMap: Map<String, Any>?,
+  actionParams: List<ActionParameter>? = emptyList()
 ) {
   // TODO Refactor: startActivityForResult is deprecated
   (this.getActivity())?.startActivityForResult(
     Intent(this, Q::class.java)
       .putExtras(
-        intentArgs(questionnaireConfig = questionnaireConfig, computedValuesMap = computedValuesMap)
+        intentArgs(
+          questionnaireConfig = questionnaireConfig,
+          computedValuesMap = computedValuesMap,
+          actionParams = actionParams
+        )
       )
       .putExtras(intentBundle),
     0


### PR DESCRIPTION
pre-populate questionnaire items with initial values through configs

- Update action parameters to include different parameter types. 
- Include parameters to specify questionnaire item `linkId`, `dataType`, and `value `for population as the initial value

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #1769 

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
