### PR TITLE
[Quest/Malawi Core] Add Loading indicator when fetching configs on Login Screen

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginScreen.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginScreen.kt
@@ -16,6 +16,8 @@
 
 package org.smartregister.fhircore.engine.ui.login
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -71,6 +73,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -93,28 +96,35 @@ const val LOGIN_ERROR_TEXT_TAG = "loginErrorTextTag"
 const val LOGIN_FOOTER = "loginFooter"
 const val APP_LOGO_TAG = "appLogoTag"
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun LoginScreen(loginViewModel: LoginViewModel) {
 
   val viewConfiguration by loginViewModel.loginViewConfiguration.observeAsState(
     loginViewConfigurationOf()
   )
+  val loadingConfig by loginViewModel.loadingConfig.observeAsState(true)
   val username by loginViewModel.username.observeAsState("")
   val password by loginViewModel.password.observeAsState("")
   val loginErrorState by loginViewModel.loginErrorState.observeAsState(null)
   val showProgressBar by loginViewModel.showProgressBar.observeAsState(false)
-
-  LoginPage(
-    viewConfiguration = viewConfiguration,
-    username = username,
-    onUsernameChanged = { loginViewModel.onUsernameUpdated(it) },
-    password = password,
-    onPasswordChanged = { loginViewModel.onPasswordUpdated(it) },
-    forgotPassword = { loginViewModel.forgotPassword() },
-    onLoginButtonClicked = { loginViewModel.attemptRemoteLogin() },
-    loginErrorState = loginErrorState,
-    showProgressBar = showProgressBar,
-  )
+  AnimatedContent(targetState = loadingConfig) {
+    if (!loadingConfig) {
+      LoginPage(
+        viewConfiguration = viewConfiguration,
+        username = username,
+        onUsernameChanged = { loginViewModel.onUsernameUpdated(it) },
+        password = password,
+        onPasswordChanged = { loginViewModel.onPasswordUpdated(it) },
+        forgotPassword = { loginViewModel.forgotPassword() },
+        onLoginButtonClicked = { loginViewModel.attemptRemoteLogin() },
+        loginErrorState = loginErrorState,
+        showProgressBar = showProgressBar,
+      )
+    } else {
+      LoginScreenLoadingConfig()
+    }
+  }
 }
 
 @Composable
@@ -380,6 +390,23 @@ fun ForgotPasswordDialog(
   )
 }
 
+@Composable
+fun LoginScreenLoadingConfig() {
+  Column(
+    modifier = Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    Column(
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+      horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+      CircularProgressBar()
+      Text(text = stringResource(id = R.string.loading), textAlign = TextAlign.Center)
+    }
+  }
+}
+
 @Preview(showBackground = true)
 @ExcludeFromJacocoGeneratedReport
 @Composable
@@ -408,4 +435,11 @@ fun LoginScreenPreviewDarkMode() {
     forgotPassword = {},
     onLoginButtonClicked = {}
   )
+}
+
+@Preview(showBackground = true)
+@ExcludeFromJacocoGeneratedReport
+@Composable
+private fun LoginScreenLoadingConfigPreview() {
+  LoginScreenLoadingConfig()
 }

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginScreen.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginScreen.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -396,15 +395,7 @@ fun LoginScreenLoadingConfig() {
     modifier = Modifier.fillMaxSize(),
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally
-  ) {
-    Column(
-      verticalArrangement = Arrangement.spacedBy(12.dp),
-      horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-      CircularProgressBar()
-      Text(text = stringResource(id = R.string.loading), textAlign = TextAlign.Center)
-    }
-  }
+  ) { CircularProgressBar(text = stringResource(id = R.string.loading)) }
 }
 
 @Preview(showBackground = true)

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginViewModel.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/login/LoginViewModel.kt
@@ -171,6 +171,10 @@ constructor(
   val loginViewConfiguration: LiveData<LoginViewConfiguration>
     get() = _loginViewConfiguration
 
+  private val _loadingConfig = MutableLiveData(true)
+  val loadingConfig: LiveData<Boolean>
+    get() = _loadingConfig
+
   fun fetchLoggedInPractitioner(userInfo: UserInfo) {
     if (!userInfo.keycloakUuid.isNullOrEmpty() &&
         sharedPreferences.read(LOGGED_IN_PRACTITIONER, null) == null
@@ -222,6 +226,7 @@ constructor(
 
   fun updateViewConfigurations(registerViewConfiguration: LoginViewConfiguration) {
     _loginViewConfiguration.value = registerViewConfiguration
+    _loadingConfig.value = false
   }
 
   fun onUsernameUpdated(username: String) {

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/components/LoginScreenTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/components/LoginScreenTest.kt
@@ -53,6 +53,7 @@ class LoginScreenTest : RobolectricTest() {
   private val app = ApplicationProvider.getApplicationContext<Application>()
   private val username = MutableLiveData("")
   private val password = MutableLiveData("")
+  private val loadingConfig = MutableLiveData(false)
   private val loginError: LiveData<LoginErrorState?> = MutableLiveData(null)
   private val showProgressBar = MutableLiveData(false)
   private val loginConfig = loginViewConfigurationOf()
@@ -64,6 +65,7 @@ class LoginScreenTest : RobolectricTest() {
         every { loginViewConfiguration } returns MutableLiveData(loginConfig)
         every { username } returns this@LoginScreenTest.username
         every { password } returns this@LoginScreenTest.password
+        every { loadingConfig } returns this@LoginScreenTest.loadingConfig
         every { loginErrorState } returns this@LoginScreenTest.loginError
         every { showProgressBar } returns this@LoginScreenTest.showProgressBar
         every { onUsernameUpdated(any()) } answers

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/components/LoginScreenWithLogoTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/components/LoginScreenWithLogoTest.kt
@@ -40,6 +40,7 @@ class LoginScreenWithLogoTest : RobolectricTest() {
   private lateinit var loginViewModelWithLogo: LoginViewModel
   private val username = MutableLiveData("")
   private val password = MutableLiveData("")
+  private val loadingConfig = MutableLiveData(false)
   private val loginErrorState: LiveData<LoginErrorState?> = MutableLiveData(null)
   private val showProgressBar = MutableLiveData(false)
   private val loginConfig = loginViewConfigurationOf(showLogo = true)
@@ -53,6 +54,7 @@ class LoginScreenWithLogoTest : RobolectricTest() {
         every { password } returns this@LoginScreenWithLogoTest.password
         every { loginErrorState } returns this@LoginScreenWithLogoTest.loginErrorState
         every { showProgressBar } returns this@LoginScreenWithLogoTest.showProgressBar
+        every { loadingConfig } returns this@LoginScreenWithLogoTest.loadingConfig
         every { onUsernameUpdated(any()) } answers
           {
             this@LoginScreenWithLogoTest.username.value = firstArg()

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginScreenTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/login/LoginScreenTest.kt
@@ -57,6 +57,7 @@ class LoginScreenTest : RobolectricTest() {
         every { username } returns MutableLiveData("demo")
         every { password } returns MutableLiveData("1234")
         every { loginErrorState } returns MutableLiveData(null)
+        every { loadingConfig } returns MutableLiveData(false)
         every { showProgressBar } returns MutableLiveData(false)
         every { loginViewConfiguration } returns MutableLiveData(loginConfig)
       }


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes [this](https://github.com/opensrp/fhir-resources/issues/393) 

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
