### PR TITLE
[Quest/MWCore] Fix refresh token not invalidating on network Exception

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/auth/AccountAuthenticator.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/auth/AccountAuthenticator.kt
@@ -176,6 +176,7 @@ constructor(
 
   fun getUserInfo(): Call<ResponseBody> = oAuthService.userInfo()
 
+  @Throws(NetworkErrorException::class)
   fun refreshToken(refreshToken: String): OAuthResponse? {
     val data = buildOAuthPayload(REFRESH_TOKEN)
     data[REFRESH_TOKEN] = refreshToken
@@ -183,7 +184,7 @@ constructor(
       oAuthService.fetchToken(data).execute().body()
     } catch (exception: Exception) {
       Timber.e("Failed to refresh token, refresh token may have expired", exception)
-      return null
+      throw NetworkErrorException(exception)
     }
   }
 
@@ -349,7 +350,7 @@ constructor(
     launchScreen(AppSettingActivity::class.java)
   }
 
-  fun loadRefreshedSessionAccount(callback: AccountManagerCallback<Bundle>) {
+  fun refreshSessionAuthToken(callback: AccountManagerCallback<Bundle>) {
     tokenManagerService.getActiveAccount()?.run {
       val accountType = getAccountType()
       var authToken = accountManager.peekAuthToken(this, accountType)

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/AccountAuthenticatorTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/AccountAuthenticatorTest.kt
@@ -482,6 +482,10 @@ class AccountAuthenticatorTest : RobolectricTest() {
 
   @Test
   fun loadRefreshedSessionAccountRefreshesAccessTokenIfExpired() = runBlockingTest {
+    val callMock = mockk<Call<OAuthResponse>>()
+    val mockResponse = Response.success<OAuthResponse?>(OAuthResponse("testToken"))
+    every { callMock.execute() } returns mockResponse
+    every { oAuthService.fetchToken(any()) } returns callMock
     every { tokenManagerService.getActiveAccount() } returns mockk()
     every { tokenManagerService.isTokenActive(any()) } returns false
     every { accountManager.getAuthToken(any(), any(), any(), any<Boolean>(), any(), any()) } returns
@@ -489,8 +493,9 @@ class AccountAuthenticatorTest : RobolectricTest() {
     every { accountManager.peekAuthToken(any(), any()) } returns "auth-token"
     every { accountManager.notifyAccountAuthenticated(any()) } returns true
     every { accountAuthenticator.getRefreshToken() } returns "refresh-token"
+    every { accountAuthenticator.updateSession(any()) } returns mockk()
 
-    accountAuthenticator.loadRefreshedSessionAccount(mockk())
+    accountAuthenticator.refreshSessionAuthToken(mockk())
     verify { accountAuthenticator.refreshToken(any()) }
   }
 
@@ -506,7 +511,7 @@ class AccountAuthenticatorTest : RobolectricTest() {
     every { accountAuthenticator.refreshToken("refresh-token") } throws
       Exception("Failed to refresh token")
 
-    accountAuthenticator.loadRefreshedSessionAccount(mockk())
+    accountAuthenticator.refreshSessionAuthToken(mockk())
     verify { accountManager.invalidateAuthToken(any(), any()) }
   }
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModel.kt
@@ -111,7 +111,7 @@ constructor(
       }
       is AppMainEvent.RefreshAuthToken -> {
         Timber.e("Refreshing token")
-        accountAuthenticator.loadRefreshedSessionAccount { accountBundleFuture ->
+        accountAuthenticator.refreshSessionAuthToken { accountBundleFuture ->
           val bundle = accountBundleFuture.result
           bundle.getParcelable<Intent>(AccountManager.KEY_INTENT).let { intent ->
             if (intent == null && bundle.containsKey(AccountManager.KEY_AUTHTOKEN)) {


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes [this](https://github.com/opensrp/fhir-resources/issues/364) 

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
