### PR TITLE
Test AlertDialog neutralbutton color

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/base/AlertDialogue.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/base/AlertDialogue.kt
@@ -25,6 +25,7 @@ import android.os.Build
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 import androidx.core.view.setPadding
 import java.util.Calendar
 import java.util.Date
@@ -84,7 +85,7 @@ object AlertDialogue {
 
     dialog
       .getButton(AlertDialog.BUTTON_NEUTRAL)
-      .setTextColor(context.resources.getColor(R.color.grey_text_color))
+      .setTextColor(ContextCompat.getColor(context, R.color.grey_text_color))
     dialog.findViewById<View>(R.id.pr_circular)?.apply {
       if (alertIntent == AlertIntent.PROGRESS) {
         this.show()

--- a/android/engine/src/main/res/values/strings.xml
+++ b/android/engine/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="error_loading_form">Error loading form</string>
     <string name="error_saving_form">Error encountered cannot save form</string>
     <string name="form_progress_message">Processing data. Please wait</string>
-    <string name="questionnaire_alert_back_pressed_message">Are you sure you want to go back?</string>
+    <string name="questionnaire_alert_back_pressed_message">Please confirm that you have all details filled in before submission</string>
     <string name="questionnaire_in_progress_alert_back_pressed_message">Are you sure you want to discard the answers?</string>
     <string name="questionnaire_alert_back_pressed_title">Submit details</string>
     <string name="questionnaire_alert_back_pressed_button_title">Save</string>

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/base/AlertDialogueTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/base/AlertDialogueTest.kt
@@ -22,6 +22,7 @@ import android.content.DialogInterface
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import java.util.Date
 import org.junit.Assert
 import org.junit.Before
@@ -246,5 +247,25 @@ class AlertDialogueTest : ActivityRobolectricTest() {
 
   override fun getActivity(): Activity {
     return context
+  }
+
+  @Test
+  fun testAlertDialogNeutralButtonReturnsCorrectColor() {
+    AlertDialogue.showInfoAlert(
+      context = context,
+      message = "Please confirm that you have all details filled in before submission",
+      title = "Submit Details",
+      confirmButtonText = R.string.questionnaire_alert_neutral_button_title
+    )
+
+    val dialog = shadowOf(ShadowAlertDialog.getLatestAlertDialog())
+    val alertDialog = ReflectionHelpers.getField<AlertDialog>(dialog, "realAlertDialog")
+
+    // test an additional cancel or neutral button in confirm alert
+    val neutralButton = alertDialog.getButton(DialogInterface.BUTTON_NEUTRAL)
+    Assert.assertEquals(
+      ContextCompat.getColor(context, R.color.grey_text_color),
+      neutralButton.currentTextColor
+    )
   }
 }


### PR DESCRIPTION
* Add to check correct color for neutralbutton is shown
* Replace deprecated **context.resources.getColor** with **ContextCompact.getColor**

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Enhances PR #1999  

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
