### PR TITLE
[Mwcore] Patient change status as an option to the patient profile

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactory.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactory.kt
@@ -22,149 +22,112 @@ import org.smartregister.fhircore.engine.ui.theme.DangerColor
 import org.smartregister.fhircore.quest.R
 
 class OverflowMenuFactory @Inject constructor() {
-  private val overflowMenuMap: Map<OverflowMenuHost, MutableList<OverflowMenuItem>> by lazy {
-    OverflowMenuHost.values().associate { Pair(it, it.overflowMenuItems.toMutableList()) }
-  }
-
-  /** Retrieve [overflowMenuHost]. Remove any menu ids that satisfy the [conditions] */
-  fun retrieveOverflowMenuItems(
-    overflowMenuHost: OverflowMenuHost,
-    conditions: List<Pair<Int, Boolean>> = emptyList()
-  ): MutableList<OverflowMenuItem> {
-    val overflowMenuItems = overflowMenuMap.getValue(overflowMenuHost)
-    conditions.forEach { conditionPair: Pair<Int, Boolean> ->
-      overflowMenuItems.removeIf { it.id == conditionPair.first && conditionPair.second }
+    private val overflowMenuMap: Map<OverflowMenuHost, MutableList<OverflowMenuItem>> by lazy {
+        OverflowMenuHost.values().associate { Pair(it, it.overflowMenuItems.toMutableList()) }
     }
-    return overflowMenuItems
-  }
+
+    /** Retrieve [overflowMenuHost]. Remove any menu ids that satisfy the [conditions] */
+    fun retrieveOverflowMenuItems(
+        overflowMenuHost: OverflowMenuHost,
+        conditions: List<Pair<Int, Boolean>> = emptyList()
+    ): MutableList<OverflowMenuItem> {
+        val overflowMenuItems = overflowMenuMap.getValue(overflowMenuHost)
+        conditions.forEach { conditionPair: Pair<Int, Boolean> ->
+            overflowMenuItems.removeIf { it.id == conditionPair.first && conditionPair.second }
+        }
+        return overflowMenuItems
+    }
 }
 
 /** Refers to an a screen that contains */
 enum class OverflowMenuHost(val overflowMenuItems: List<OverflowMenuItem>) {
-  FAMILY_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.family_details, R.string.family_details),
-      OverflowMenuItem(R.id.change_family_head, R.string.change_family_head),
-      OverflowMenuItem(R.id.family_activity, R.string.family_activity),
-      OverflowMenuItem(R.id.view_past_encounters, R.string.view_past_encounters),
-      OverflowMenuItem(
-        id = R.id.remove_family,
-        titleResource = R.string.remove_family,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
+    FAMILY_PROFILE(
+        listOf(
+            OverflowMenuItem(R.id.family_details, R.string.family_details),
+            OverflowMenuItem(R.id.change_family_head, R.string.change_family_head),
+            OverflowMenuItem(R.id.family_activity, R.string.family_activity),
+            OverflowMenuItem(R.id.view_past_encounters, R.string.view_past_encounters),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    PATIENT_PROFILE(
+        listOf(
+            OverflowMenuItem(R.id.individual_details, R.string.individual_details),
+            OverflowMenuItem(R.id.view_family, R.string.view_family),
+            OverflowMenuItem(R.id.record_as_anc, R.string.record_as_anc),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    NEWLY_DIAGNOSED_PROFILE(
+        listOf(
+            OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
+            OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
+            OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
+            OverflowMenuItem(R.id.view_children, R.string.view_children_x),
+            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    ART_CLIENT_PROFILE(
+        listOf(
+            OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
+            OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
+            OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
+            OverflowMenuItem(R.id.view_children, R.string.view_children_x),
+            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    EXPOSED_INFANT_PROFILE(
+        listOf(
+            OverflowMenuItem(R.id.hiv_test_and_results, R.string.hiv_test_and_results),
+            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    CHILD_CONTACT_PROFILE(
+        listOf(
+            OverflowMenuItem(
+                R.id.hiv_test_and_next_appointment,
+                R.string.hiv_test_and_next_appointment
+            ),
+            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    SEXUAL_CONTACT_PROFILE(
+        listOf(
+            OverflowMenuItem(
+                R.id.hiv_test_and_next_appointment,
+                R.string.hiv_test_and_next_appointment
+            ),
+            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    COMMUNITY_POSITIVE_PROFILE(
+        listOf(
+            OverflowMenuItem(
+                R.id.hiv_test_and_next_appointment,
+                R.string.hiv_test_and_next_appointment
+            ),
+            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
+    ),
+    NOT_ON_ART(
+        listOf(
+            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+        )
     )
-  ),
-  PATIENT_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.individual_details, R.string.individual_details),
-      OverflowMenuItem(R.id.view_family, R.string.view_family),
-      OverflowMenuItem(R.id.record_as_anc, R.string.record_as_anc),
-      OverflowMenuItem(
-        id = R.id.remove_family_member,
-        titleResource = R.string.remove_this_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  ),
-  NEWLY_DIAGNOSED_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
-      OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
-      OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
-      OverflowMenuItem(R.id.view_children, R.string.view_children_x),
-      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-      OverflowMenuItem(
-        id = R.id.remove_hiv_patient,
-        titleResource = R.string.remove_active_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  ),
-  ART_CLIENT_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
-      OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
-      OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
-      OverflowMenuItem(R.id.view_children, R.string.view_children_x),
-      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-      OverflowMenuItem(
-        id = R.id.remove_hiv_patient,
-        titleResource = R.string.remove_active_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  ),
-  EXPOSED_INFANT_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.hiv_test_and_results, R.string.hiv_test_and_results),
-      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-      OverflowMenuItem(
-        id = R.id.remove_hiv_patient,
-        titleResource = R.string.remove_active_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  ),
-  CHILD_CONTACT_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.hiv_test_and_next_appointment, R.string.hiv_test_and_next_appointment),
-      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-      OverflowMenuItem(
-        id = R.id.remove_hiv_patient,
-        titleResource = R.string.remove_active_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  ),
-  SEXUAL_CONTACT_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.hiv_test_and_next_appointment, R.string.hiv_test_and_next_appointment),
-      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-      OverflowMenuItem(
-        id = R.id.remove_hiv_patient,
-        titleResource = R.string.remove_active_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  ),
-  COMMUNITY_POSITIVE_PROFILE(
-    listOf(
-      OverflowMenuItem(R.id.hiv_test_and_next_appointment, R.string.hiv_test_and_next_appointment),
-      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-      OverflowMenuItem(
-        id = R.id.remove_hiv_patient,
-        titleResource = R.string.remove_active_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  ),
-  NOT_ON_ART(
-    listOf(
-      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-      OverflowMenuItem(
-        id = R.id.remove_hiv_patient,
-        titleResource = R.string.remove_active_person,
-        titleColor = DangerColor,
-        confirmAction = true
-      )
-    )
-  )
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactory.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactory.kt
@@ -18,116 +18,106 @@ package org.smartregister.fhircore.quest.navigation
 
 import javax.inject.Inject
 import org.smartregister.fhircore.engine.domain.model.OverflowMenuItem
-import org.smartregister.fhircore.engine.ui.theme.DangerColor
 import org.smartregister.fhircore.quest.R
 
 class OverflowMenuFactory @Inject constructor() {
-    private val overflowMenuMap: Map<OverflowMenuHost, MutableList<OverflowMenuItem>> by lazy {
-        OverflowMenuHost.values().associate { Pair(it, it.overflowMenuItems.toMutableList()) }
-    }
+  private val overflowMenuMap: Map<OverflowMenuHost, MutableList<OverflowMenuItem>> by lazy {
+    OverflowMenuHost.values().associate { Pair(it, it.overflowMenuItems.toMutableList()) }
+  }
 
-    /** Retrieve [overflowMenuHost]. Remove any menu ids that satisfy the [conditions] */
-    fun retrieveOverflowMenuItems(
-        overflowMenuHost: OverflowMenuHost,
-        conditions: List<Pair<Int, Boolean>> = emptyList()
-    ): MutableList<OverflowMenuItem> {
-        val overflowMenuItems = overflowMenuMap.getValue(overflowMenuHost)
-        conditions.forEach { conditionPair: Pair<Int, Boolean> ->
-            overflowMenuItems.removeIf { it.id == conditionPair.first && conditionPair.second }
-        }
-        return overflowMenuItems
+  /** Retrieve [overflowMenuHost]. Remove any menu ids that satisfy the [conditions] */
+  fun retrieveOverflowMenuItems(
+    overflowMenuHost: OverflowMenuHost,
+    conditions: List<Pair<Int, Boolean>> = emptyList()
+  ): MutableList<OverflowMenuItem> {
+    val overflowMenuItems = overflowMenuMap.getValue(overflowMenuHost)
+    conditions.forEach { conditionPair: Pair<Int, Boolean> ->
+      overflowMenuItems.removeIf { it.id == conditionPair.first && conditionPair.second }
     }
+    return overflowMenuItems
+  }
 }
 
 /** Refers to an a screen that contains */
 enum class OverflowMenuHost(val overflowMenuItems: List<OverflowMenuItem>) {
-    FAMILY_PROFILE(
-        listOf(
-            OverflowMenuItem(R.id.family_details, R.string.family_details),
-            OverflowMenuItem(R.id.change_family_head, R.string.change_family_head),
-            OverflowMenuItem(R.id.family_activity, R.string.family_activity),
-            OverflowMenuItem(R.id.view_past_encounters, R.string.view_past_encounters),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    PATIENT_PROFILE(
-        listOf(
-            OverflowMenuItem(R.id.individual_details, R.string.individual_details),
-            OverflowMenuItem(R.id.view_family, R.string.view_family),
-            OverflowMenuItem(R.id.record_as_anc, R.string.record_as_anc),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    NEWLY_DIAGNOSED_PROFILE(
-        listOf(
-            OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
-            OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
-            OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
-            OverflowMenuItem(R.id.view_children, R.string.view_children_x),
-            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    ART_CLIENT_PROFILE(
-        listOf(
-            OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
-            OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
-            OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
-            OverflowMenuItem(R.id.view_children, R.string.view_children_x),
-            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    EXPOSED_INFANT_PROFILE(
-        listOf(
-            OverflowMenuItem(R.id.hiv_test_and_results, R.string.hiv_test_and_results),
-            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    CHILD_CONTACT_PROFILE(
-        listOf(
-            OverflowMenuItem(
-                R.id.hiv_test_and_next_appointment,
-                R.string.hiv_test_and_next_appointment
-            ),
-            OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
-            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    SEXUAL_CONTACT_PROFILE(
-        listOf(
-            OverflowMenuItem(
-                R.id.hiv_test_and_next_appointment,
-                R.string.hiv_test_and_next_appointment
-            ),
-            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    COMMUNITY_POSITIVE_PROFILE(
-        listOf(
-            OverflowMenuItem(
-                R.id.hiv_test_and_next_appointment,
-                R.string.hiv_test_and_next_appointment
-            ),
-            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-            OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
-    ),
-    NOT_ON_ART(
-        listOf(
-            OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
-            OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
-        )
+  FAMILY_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.family_details, R.string.family_details),
+      OverflowMenuItem(R.id.change_family_head, R.string.change_family_head),
+      OverflowMenuItem(R.id.family_activity, R.string.family_activity),
+      OverflowMenuItem(R.id.view_past_encounters, R.string.view_past_encounters),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
     )
+  ),
+  PATIENT_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.individual_details, R.string.individual_details),
+      OverflowMenuItem(R.id.view_family, R.string.view_family),
+      OverflowMenuItem(R.id.record_as_anc, R.string.record_as_anc),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  ),
+  NEWLY_DIAGNOSED_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
+      OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
+      OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
+      OverflowMenuItem(R.id.view_children, R.string.view_children_x),
+      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  ),
+  ART_CLIENT_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
+      OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
+      OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
+      OverflowMenuItem(R.id.view_children, R.string.view_children_x),
+      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  ),
+  EXPOSED_INFANT_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.hiv_test_and_results, R.string.hiv_test_and_results),
+      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  ),
+  CHILD_CONTACT_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.hiv_test_and_next_appointment, R.string.hiv_test_and_next_appointment),
+      OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
+      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  ),
+  SEXUAL_CONTACT_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.hiv_test_and_next_appointment, R.string.hiv_test_and_next_appointment),
+      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  ),
+  COMMUNITY_POSITIVE_PROFILE(
+    listOf(
+      OverflowMenuItem(R.id.hiv_test_and_next_appointment, R.string.hiv_test_and_next_appointment),
+      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+      OverflowMenuItem(R.id.clinic_history, R.string.clinic_history),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  ),
+  NOT_ON_ART(
+    listOf(
+      OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),
+      OverflowMenuItem(R.id.patient_change_status, R.string.change_status),
+    )
+  )
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
@@ -300,12 +300,6 @@ constructor(
               questionnaireType = QuestionnaireType.DEFAULT,
               populationResources = profile.populationResources
             )
-          R.id.remove_hiv_patient ->
-            event.context.launchQuestionnaire<HivPatientQuestionnaireActivity>(
-              questionnaireId = REMOVE_HIV_PATIENT_FORM,
-              clientIdentifier = patientId,
-              populationResources = profile.populationResources
-            )
           R.id.patient_change_status ->
             event.context.launchQuestionnaire<QuestionnaireActivity>(
               questionnaireId = PATIENT_CHANGE_STATUS,
@@ -432,7 +426,6 @@ constructor(
     const val HIV_TEST_AND_RESULTS_FORM = "exposed-infant-hiv-test-and-results"
     const val HIV_TEST_AND_NEXT_APPOINTMENT_FORM =
       "contact-and-community-positive-hiv-test-and-next-appointment"
-    const val REMOVE_HIV_PATIENT_FORM = "remove-person"
     const val PATIENT_FINISH_VISIT = "patient-finish-visit"
     const val PATIENT_CHANGE_STATUS = "patient-change-status"
   }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
@@ -306,14 +306,13 @@ constructor(
               clientIdentifier = patientId,
               populationResources = profile.populationResources
             )
-          R.id.patient_change_status -> {
+          R.id.patient_change_status ->
             event.context.launchQuestionnaire<QuestionnaireActivity>(
               questionnaireId = PATIENT_CHANGE_STATUS,
               clientIdentifier = patientId,
               questionnaireType = QuestionnaireType.DEFAULT,
               populationResources = profile.populationResources
             )
-          }
           else -> {}
         }
       }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
@@ -63,7 +63,6 @@ import org.smartregister.fhircore.quest.navigation.OverflowMenuFactory
 import org.smartregister.fhircore.quest.navigation.OverflowMenuHost
 import org.smartregister.fhircore.quest.ui.family.remove.member.RemoveFamilyMemberQuestionnaireActivity
 import org.smartregister.fhircore.quest.ui.patient.profile.childcontact.ChildContactPagingSource
-import org.smartregister.fhircore.quest.ui.patient.remove.HivPatientQuestionnaireActivity
 import org.smartregister.fhircore.quest.ui.shared.models.ProfileViewData
 import org.smartregister.fhircore.quest.ui.shared.models.RegisterViewData
 import org.smartregister.fhircore.quest.util.mappers.ProfileViewDataMapper

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
@@ -306,6 +306,14 @@ constructor(
               clientIdentifier = patientId,
               populationResources = profile.populationResources
             )
+          R.id.patient_change_status -> {
+            event.context.launchQuestionnaire<QuestionnaireActivity>(
+              questionnaireId = PATIENT_CHANGE_STATUS,
+              clientIdentifier = patientId,
+              questionnaireType = QuestionnaireType.DEFAULT,
+              populationResources = profile.populationResources
+            )
+          }
           else -> {}
         }
       }
@@ -427,5 +435,6 @@ constructor(
       "contact-and-community-positive-hiv-test-and-next-appointment"
     const val REMOVE_HIV_PATIENT_FORM = "remove-person"
     const val PATIENT_FINISH_VISIT = "patient-finish-visit"
+    const val PATIENT_CHANGE_STATUS = "patient-change-status"
   }
 }

--- a/android/quest/src/main/res/values/ids.xml
+++ b/android/quest/src/main/res/values/ids.xml
@@ -24,4 +24,5 @@
     <item name="hiv_test_and_results"  type="id"/>
     <item name="hiv_test_and_next_appointment"  type="id"/>
     <item name="remove_hiv_patient"  type="id"/>
+    <item name="patient_change_status"  type="id"/>
 </resources>

--- a/android/quest/src/main/res/values/strings.xml
+++ b/android/quest/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="hiv_test_and_next_appointment">HIV Test and Next Appointment</string>
     <string name="remove_hiv_patient_warning">%1$s will be removed permanently. This action can’t be undone.</string>
     <string name="remove_active_person">Remove This Person</string>
+    <string name="change_status">Change Status</string>
 
     <!-- SideMenu option strings-->
     <string name="device_to_device_sync">Device to device sync</string>

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactoryTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactoryTest.kt
@@ -60,7 +60,7 @@ class OverflowMenuFactoryTest : RobolectricTest() {
     val uiProfileChildContact =
       overflowMenuFactory.retrieveOverflowMenuItems(OverflowMenuHost.CHILD_CONTACT_PROFILE)
     Assert.assertNotNull(uiProfileChildContact)
-    Assert.assertEquals(5, uiProfileChildContact.size)
+    Assert.assertEquals(4, uiProfileChildContact.size)
 
     val uiProfileSexualContact =
       overflowMenuFactory.retrieveOverflowMenuItems(OverflowMenuHost.SEXUAL_CONTACT_PROFILE)


### PR DESCRIPTION
Goal :
1. In the toolbar overflow menu, remove the "Remove This Person" option
2. In the toolbar overflow menu, add a new option called "Change Status"
Note:
The "Change Status" option should be similar in appearance to the remaining options and NOT in red
These changes should be applicable to all patient categories
On tap, the "Change Status" option should open the questionnaire patient-change-status
"Change Status" will be the last item in the overflow list



**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] 

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
