### PR TITLE
remove version code and name

### DIFF
--- a/android/quest/build.gradle
+++ b/android/quest/build.gradle
@@ -158,48 +158,36 @@ android {
             dimension "apps"
             applicationIdSuffix ".afyayangu"
             versionNameSuffix "-afyayangu"
-            versionCode 1
-            versionName "0.0.1"
         }
 
         map {
             dimension "apps"
             applicationIdSuffix ".map"
             versionNameSuffix "-map"
-            versionCode 1
-            versionName "0.0.1"
         }
 
         echis {
             dimension "apps"
             applicationIdSuffix ".echis"
             versionNameSuffix "-echis"
-            versionCode 1
-            versionName "0.0.1"
         }
 
         bunda {
             dimension "apps"
             applicationIdSuffix ".bunda"
             versionNameSuffix "-bunda"
-            versionCode 1
-            versionName "0.0.1"
         }
 
         wdf {
             dimension "apps"
             applicationIdSuffix ".wdf"
             versionNameSuffix "-wdf"
-            versionCode 1
-            versionName "0.0.1"
         }
 
         zeir {
             dimension "apps"
             applicationIdSuffix ".zeir"
             versionNameSuffix "-zeir"
-            versionCode 1
-            versionName "0.0.1"
         }
     }
     sourceSets {


### PR DESCRIPTION
These versions are not meaningful, we'll only use the primary version of the app as the version number