### PR TITLE
[Quest/Malawi Core] In the app, sort the order of the tasks on the patient profile with 'double' values bug fix

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/TaskExtension.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/TaskExtension.kt
@@ -43,7 +43,7 @@ fun Task.clinicVisitOrder(systemTag: String) =
     .filter { it.system.equals(systemTag, true) }
     .filterNot { it.code.isNullOrBlank() }
     .map { it.code.replace("_", "-").substringAfterLast("-").trim() }
-    .map { it.toDouble() }
+    .map { it.toDoubleOrNull() }
     .lastOrNull()
 
 fun Task.isGuardianVisit(systemTag: String) =

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/TaskExtension.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/TaskExtension.kt
@@ -23,6 +23,7 @@ import org.smartregister.fhircore.engine.util.DateUtils.isToday
 import org.smartregister.fhircore.engine.util.DateUtils.today
 
 const val GUARDIAN_VISIT_CODE = "guardian-visit"
+const val CLINICAL_VISIT_ORDER_CODE_REGEX_FORMAT = "clinic-visit-task-order-\\d*\\.?\\d*\$"
 
 fun Task.hasPastEnd() =
   this.hasExecutionPeriod() &&
@@ -36,13 +37,17 @@ fun Task.hasStarted() =
 
 fun Task.TaskStatus.toCoding() = Coding(this.system, this.toCode(), this.display)
 
-fun Task.clinicVisitOrder(systemTag: String) =
+fun Task.clinicVisitOrder(systemTag: String): Double? =
   this.meta
     .tag
     .asSequence()
     .filter { it.system.equals(systemTag, true) }
-    .filterNot { it.code.isNullOrBlank() }
-    .map { it.code.replace("_", "-").substringAfterLast("-").trim() }
+    .filter { !it.code.isNullOrBlank() }
+    .map { it.code.replace("_", "-") }
+    .filter {
+      it.matches(Regex(CLINICAL_VISIT_ORDER_CODE_REGEX_FORMAT, option = RegexOption.IGNORE_CASE))
+    }
+    .map { it.substringAfterLast("-").trim() }
     .map { it.toDoubleOrNull() }
     .lastOrNull()
 

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDaoTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDaoTest.kt
@@ -64,6 +64,7 @@ import org.smartregister.fhircore.engine.robolectric.RobolectricTest
 import org.smartregister.fhircore.engine.rule.CoroutineTestRule
 import org.smartregister.fhircore.engine.util.DefaultDispatcherProvider
 import org.smartregister.fhircore.engine.util.extension.asReference
+import org.smartregister.fhircore.engine.util.extension.clinicVisitOrder
 import org.smartregister.fhircore.engine.util.extension.referenceValue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -244,6 +245,9 @@ class HivRegisterDaoTest : RobolectricTest() {
     }
     assertNotNull(data)
     val hivProfileData = data as ProfileData.HivProfileData
+    val order = hivProfileData.tasks.none { it.clinicVisitOrder("") != null }
+    Assert.assertEquals(hivProfileData.tasks.isEmpty(), false)
+    Assert.assertEquals(order, true)
     assertEquals("50y", hivProfileData.age)
     assertEquals("Dist 1 City 1", hivProfileData.address)
     assertEquals("John Doe", hivProfileData.name)

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDaoTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/register/dao/HivRegisterDaoTest.kt
@@ -247,6 +247,8 @@ class HivRegisterDaoTest : RobolectricTest() {
     val hivProfileData = data as ProfileData.HivProfileData
     val order = hivProfileData.tasks.none { it.clinicVisitOrder("") != null }
     Assert.assertEquals(hivProfileData.tasks.isEmpty(), false)
+    val sorted = hivProfileData.tasks.sortedWith(compareBy { it.description }).isEmpty()
+    Assert.assertFalse(sorted)
     Assert.assertEquals(order, true)
     assertEquals("50y", hivProfileData.age)
     assertEquals("Dist 1 City 1", hivProfileData.address)

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/TaskExtensionTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/TaskExtensionTest.kt
@@ -63,6 +63,13 @@ class TaskExtensionTest {
   }
 
   @Test
+  fun `task clinicVisitOrder`() {
+    val systemTag = "https://d-tree.org"
+    Assert.assertNull(testTask1.clinicVisitOrder(systemTag))
+    Assert.assertEquals(testTask2.clinicVisitOrder(systemTag), 1.0)
+  }
+
+  @Test
   fun `task isNotCompleted`() {
     Assert.assertTrue(testTask1.isNotCompleted())
     Assert.assertFalse(testTask2.isNotCompleted())

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/TaskExtensionTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/TaskExtensionTest.kt
@@ -65,10 +65,55 @@ class TaskExtensionTest {
   @Test
   fun `task clinicVisitOrder`() {
     val systemTag = "https://d-tree.org"
-    Assert.assertNull(testTask1.clinicVisitOrder(systemTag))
+    Assert.assertEquals(3.0, testTask1.clinicVisitOrder(systemTag))
     Assert.assertEquals(testTask2.clinicVisitOrder(systemTag), 1.0)
     val task = testTask1.copy().apply { meta.tag.first().code = systemTag }
     Assert.assertNull(task.clinicVisitOrder(systemTag))
+  }
+
+  @Test
+  fun `task clinicVisitOrder null when clinic-visit-order code invalid`() {
+    val systemTag = "https://d-tree.org"
+    val task =
+      Task().apply {
+        meta.addTag(
+          Coding().apply {
+            system = systemTag
+            code = "clinic-visit-task-order-NAN"
+          }
+        )
+      }
+    Assert.assertNull(task.clinicVisitOrder(systemTag))
+  }
+
+  @Test
+  fun `task clinicVisitOrder when clinic-visit-order code is double`() {
+    val systemTag = "https://d-tree.org"
+    val task =
+      Task().apply {
+        meta.addTag(
+          Coding().apply {
+            system = systemTag
+            code = "clinic-visit-task-order-34.2"
+          }
+        )
+      }
+    Assert.assertEquals(34.2, task.clinicVisitOrder(systemTag))
+  }
+
+  @Test
+  fun `task clinicVisitOrder with when clinic-visit-order code mixed - and _`() {
+    val systemTag = "https://d-tree.org"
+    val task =
+      Task().apply {
+        meta.addTag(
+          Coding().apply {
+            system = systemTag
+            code = "CLINIC_VISIT-TASK-ORDER_48.1"
+          }
+        )
+      }
+    Assert.assertEquals(48.1, task.clinicVisitOrder(systemTag))
   }
 
   @Test

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/TaskExtensionTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/TaskExtensionTest.kt
@@ -67,6 +67,8 @@ class TaskExtensionTest {
     val systemTag = "https://d-tree.org"
     Assert.assertNull(testTask1.clinicVisitOrder(systemTag))
     Assert.assertEquals(testTask2.clinicVisitOrder(systemTag), 1.0)
+    val task = testTask1.copy().apply { meta.tag.first().code = systemTag }
+    Assert.assertNull(task.clinicVisitOrder(systemTag))
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes https://github.com/opensrp/fhir-resources/issues/890

**Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the fhircore app to verify my change fixes the issue and/or does not break the app 
