### PR TITLE
[Quest/Malawi Core] Remove the 'Viral Load Results' menu item from an ART client profile 

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactory.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactory.kt
@@ -76,7 +76,6 @@ enum class OverflowMenuHost(val overflowMenuItems: List<OverflowMenuItem>) {
     listOf(
       OverflowMenuItem(R.id.client_visit, R.string.client_visit).apply { hidden = true },
       OverflowMenuItem(R.id.guardian_visit, R.string.guardian_visit),
-      OverflowMenuItem(R.id.viral_load_results, R.string.viral_load_results),
       OverflowMenuItem(R.id.view_children, R.string.view_children_x),
       OverflowMenuItem(R.id.view_guardians, R.string.view_guardians_x),
       OverflowMenuItem(R.id.edit_profile, R.string.edit_profile),

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactoryTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/navigation/OverflowMenuFactoryTest.kt
@@ -50,7 +50,7 @@ class OverflowMenuFactoryTest : RobolectricTest() {
     val uiProfileAlreadyOnART =
       overflowMenuFactory.retrieveOverflowMenuItems(OverflowMenuHost.ART_CLIENT_PROFILE)
     Assert.assertNotNull(uiProfileAlreadyOnART)
-    Assert.assertEquals(9, uiProfileAlreadyOnART.size)
+    Assert.assertEquals(8, uiProfileAlreadyOnART.size)
 
     val uiProfileExposedInfant =
       overflowMenuFactory.retrieveOverflowMenuItems(OverflowMenuHost.EXPOSED_INFANT_PROFILE)


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] or Closes #[issue number]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 