### PR TITLE
Use apache-commons to read file to string for extractions

### DIFF
--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/robolectric/RobolectricTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/robolectric/RobolectricTest.kt
@@ -27,11 +27,11 @@ import ca.uhn.fhir.parser.IParser
 import dagger.hilt.android.testing.HiltTestApplication
 import io.mockk.clearAllMocks
 import java.io.File
-import java.io.FileReader
 import java.util.Base64
 import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.apache.commons.io.FileUtils
 import org.hl7.fhir.instance.model.api.IBaseResource
 import org.hl7.fhir.r4.context.IWorkerContext
 import org.hl7.fhir.r4.context.SimpleWorkerContext
@@ -71,8 +71,8 @@ abstract class RobolectricTest {
     val latch = CountDownLatch(1)
     val observer: Observer<T> =
       object : Observer<T> {
-        override fun onChanged(o: T?) {
-          data[0] = o
+        override fun onChanged(value: T) {
+          data[0] = value
           latch.countDown()
           liveData.removeObserver(this)
         }
@@ -169,11 +169,11 @@ abstract class RobolectricTest {
 
     fun String.readFile(systemPath: String = ASSET_BASE_PATH): String {
       val file = File("$systemPath/$this")
-      val charArray = CharArray(file.length().toInt()).apply { FileReader(file).read(this) }
-      return String(charArray)
+      return FileUtils.readFileToString(file, "UTF-8")
     }
 
-    fun String.readDir(): List<File> = File("$ASSET_BASE_PATH/$this").listFiles().toList()
+    fun String.readDir(): List<File> =
+      File("$ASSET_BASE_PATH/$this").listFiles()?.toList() ?: emptyList()
 
     @JvmStatic
     @BeforeClass


### PR DESCRIPTION
To fix[ Jackson fasterXML parsing error](https://stackoverflow.com/q/24832614) when extracting structuremap in tests

```
HAPI-1861: Failed to parse JSON encoded FHIR content: Illegal character ((CTRL-CHAR, code 0)): only regular white space (\r, \n, \t) is allowed between tokens
 at [Source: UNKNOWN; line: 108, column: 3]
ca.uhn.fhir.parser.DataFormatException: HAPI-1861: Failed to parse JSON encoded FHIR content: Illegal character ((CTRL-CHAR, code 0)): only regular white space (\r, \n, \t) is allowed between tokens
 at [Source: UNKNOWN; line: 108, column: 3]
```

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] or Closes #[issue number]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 