### PR TITLE
Add viewgenerator tests for ROW and PERSONAL_DATA viewtypes

### DIFF
--- a/android/quest/src/androidTest/java/org/smartregister/fhircore/quest/ui/shared/components/ViewGeneratorTest.kt
+++ b/android/quest/src/androidTest/java/org/smartregister/fhircore/quest/ui/shared/components/ViewGeneratorTest.kt
@@ -32,6 +32,10 @@ import org.smartregister.fhircore.engine.configuration.view.CardViewProperties
 import org.smartregister.fhircore.engine.configuration.view.ColumnArrangement
 import org.smartregister.fhircore.engine.configuration.view.ColumnProperties
 import org.smartregister.fhircore.engine.configuration.view.CompoundTextProperties
+import org.smartregister.fhircore.engine.configuration.view.PersonalDataItem
+import org.smartregister.fhircore.engine.configuration.view.PersonalDataProperties
+import org.smartregister.fhircore.engine.configuration.view.RowArrangement
+import org.smartregister.fhircore.engine.configuration.view.RowProperties
 import org.smartregister.fhircore.engine.configuration.view.ServiceCardProperties
 import org.smartregister.fhircore.engine.configuration.view.SpacerProperties
 import org.smartregister.fhircore.engine.configuration.view.TextFontWeight
@@ -496,5 +500,92 @@ class ViewGeneratorTest {
       .assertExists()
       .assertIsDisplayed()
     composeRule.onNodeWithText("Billy Brown, M, 20", useUnmergedTree = true).assertDoesNotExist()
+  }
+
+  @Test
+  fun testRowIsRenderedWhenViewTypeIsRowAndPropertyWrapContentIsTrue() {
+    composeRule.setContent {
+      GenerateView(
+        properties =
+          RowProperties(
+            wrapContent = true,
+            children =
+              listOf(
+                ButtonProperties(status = "DUE", text = "Due Task"),
+                ButtonProperties(status = "COMPLETED", text = "Completed Task"),
+                ButtonProperties(status = "READY", text = "Ready Task"),
+              ),
+            viewType = ViewType.ROW
+          ),
+        resourceData = resourceData,
+        navController = navController
+      )
+    }
+    composeRule
+      .onNodeWithText("Due Task", useUnmergedTree = true)
+      .assertExists()
+      .assertIsDisplayed()
+    composeRule.onNodeWithText("Completed Task", useUnmergedTree = true).assertExists()
+    composeRule
+      .onNodeWithText("Ready Task", useUnmergedTree = true)
+      .assertExists()
+      .assertIsDisplayed()
+  }
+
+  @Test
+  fun testRowIsRenderedWhenViewTypeIsRowAndWrapContentIsFalse() {
+    composeRule.setContent {
+      GenerateView(
+        properties =
+          RowProperties(
+            wrapContent = false,
+            alignment = ViewAlignment.CENTER,
+            arrangement = RowArrangement.START,
+            children =
+              listOf(
+                ButtonProperties(status = "DUE", text = "Due Task", visible = "true"),
+                ButtonProperties(status = "COMPLETED", text = "Completed Task", visible = "false"),
+                ButtonProperties(status = "READY", text = "Ready Task", visible = "true"),
+              ),
+            viewType = ViewType.ROW
+          ),
+        resourceData = resourceData,
+        navController = navController
+      )
+    }
+    composeRule
+      .onNodeWithText("Due Task", useUnmergedTree = true)
+      .assertExists()
+      .assertIsDisplayed()
+    composeRule.onNodeWithText("Completed Task", useUnmergedTree = true).assertDoesNotExist()
+    composeRule.onNodeWithText("Ready Task", useUnmergedTree = true).assertExists()
+  }
+
+  @Test
+  fun testGenerateViewRendersViewTypePersonalDataCorrectly() {
+    composeRule.setContent {
+      GenerateView(
+        properties =
+          PersonalDataProperties(
+            personalDataItems =
+              listOf(
+                PersonalDataItem(
+                  label =
+                    CompoundTextProperties(
+                      primaryText = "Sex",
+                    ),
+                  displayValue =
+                    CompoundTextProperties(
+                      primaryText = "Male",
+                    )
+                )
+              )
+          ),
+        resourceData = resourceData,
+        navController = navController
+      )
+    }
+    composeRule.onNodeWithText("Sex").assertIsDisplayed()
+    composeRule.onNodeWithText("Male").assertIsDisplayed()
   }
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/components/ViewGenerator.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/components/ViewGenerator.kt
@@ -146,7 +146,6 @@ fun GenerateView(
             if (isWeighted) Arrangement.spacedBy(properties.spacedBy.dp)
             else properties.arrangement?.position ?: Arrangement.Start
         ) {
-          children.any { it.weight > 0 }
           for (child in children) {
             GenerateView(
               modifier = generateModifier(child),


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] or Closes #[issue number]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 