### PR TITLE
[Quest/MWCore] Fix multiple linkid answer crash when populating resources

### DIFF
--- a/android/engine/build.gradle
+++ b/android/engine/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     api("androidx.compose.material:material-icons-core:$composeVersion")
     api("androidx.compose.material:material-icons-extended:$composeVersion")
     api("androidx.compose.runtime:runtime-livedata:$composeVersion")
-    api("androidx.navigation:navigation-compose:2.5.0-alpha03")
+    api("androidx.navigation:navigation-compose:2.5.3")
     api ("androidx.hilt:hilt-navigation-compose:1.0.0")
     api("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.0-alpha04")
     api("androidx.paging:paging-compose:1.0.0-alpha16")

--- a/android/engine/build.gradle
+++ b/android/engine/build.gradle
@@ -184,12 +184,12 @@ dependencies {
     def coroutineVersion = '1.6.0'
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion")
-    api("org.smartregister:contrib-barcode:0.1.0-beta3-preview4-SNAPSHOT"){
+    api("org.smartregister:contrib-barcode:0.1.0-beta3-preview5-SNAPSHOT"){
         transitive = true
         exclude group: 'com.google.android.fhir', module: 'common'
         exclude group: 'com.google.android.fhir', module: 'engine'
     }
-    api('org.smartregister:data-capture:1.0.0-preview3-SNAPSHOT') {
+    api('org.smartregister:data-capture:1.0.0-preview5-SNAPSHOT') {
         transitive = true
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
         exclude group: 'javax.xml.bind', module: 'jaxb-api'

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivity.kt
@@ -59,6 +59,7 @@ import org.smartregister.fhircore.engine.ui.questionnaire.QuestionnaireItemViewH
 import org.smartregister.fhircore.engine.util.DefaultDispatcherProvider
 import org.smartregister.fhircore.engine.util.extension.FieldType
 import org.smartregister.fhircore.engine.util.extension.decodeResourceFromString
+import org.smartregister.fhircore.engine.util.extension.distinctifyLinkId
 import org.smartregister.fhircore.engine.util.extension.encodeResourceToString
 import org.smartregister.fhircore.engine.util.extension.find
 import org.smartregister.fhircore.engine.util.extension.generateMissingItems
@@ -167,35 +168,11 @@ open class QuestionnaireActivity : BaseMultiLanguageActivity(), View.OnClickList
         .setShowSubmitButton(true)
         .setCustomQuestionnaireItemViewHolderFactoryMatchersProvider(DEFAULT_PROVIDER)
         .setIsReadOnly(questionnaireType.isReadOnly())
-    questionnaireResponse
-      ?.apply {
-        // Ensure multiple linkId only when they have answers, otherwise only have one distinct
-        // linkId
-        fun distinctifyLinkId(
-          itemComponents: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>
-        ): List<QuestionnaireResponse.QuestionnaireResponseItemComponent> {
-          return itemComponents
-            .groupBy { it.linkId }
-            .flatMap {
-              it.value.filter(QuestionnaireResponse.QuestionnaireResponseItemComponent::hasAnswer)
-                .ifEmpty {
-                  it.value.distinctBy { elem ->
-                    elem.item.joinToString(
-                      transform =
-                        QuestionnaireResponse.QuestionnaireResponseItemComponent::getLinkId
-                    )
-                  }
-                }
-            }
-            .onEach { it.item = distinctifyLinkId(it.item) }
-        }
-
-        item = distinctifyLinkId(item)
-      }
-      ?.let {
-        //        Timber.e(it.encodeResourceToString())
-        questionnaireFragmentBuilder.setQuestionnaireResponse(it.encodeResourceToString())
-      }
+    questionnaireResponse?.let {
+      it.distinctifyLinkId()
+      //        Timber.e(it.encodeResourceToString())
+      questionnaireFragmentBuilder.setQuestionnaireResponse(it.encodeResourceToString())
+    }
     intent.getStringExtra(QUESTIONNAIRE_LAUNCH_CONTEXT)?.let {
       questionnaireFragmentBuilder.setQuestionnaireLaunchContext(it)
     }

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivity.kt
@@ -197,7 +197,7 @@ open class QuestionnaireActivity : BaseMultiLanguageActivity(), View.OnClickList
         questionnaireFragmentBuilder.setQuestionnaireResponse(it.encodeResourceToString())
       }
     intent.getStringExtra(QUESTIONNAIRE_LAUNCH_CONTEXT)?.let {
-      questionnaireFragmentBuilder.setQuestionnaireResourceContext(it)
+      questionnaireFragmentBuilder.setQuestionnaireLaunchContext(it)
     }
 
     fragment = questionnaireFragmentBuilder.build()

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireExtension.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireExtension.kt
@@ -120,3 +120,26 @@ fun List<Questionnaire.QuestionnaireItemComponent>.find(
     }
   }
 }
+
+/** To ensure multiple linkId only when they have answers, otherwise only have one distinct */
+fun QuestionnaireResponse.distinctifyLinkId() {
+  fun distinctLinkId(
+    itemComponents: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>
+  ): List<QuestionnaireResponse.QuestionnaireResponseItemComponent> {
+    return itemComponents
+      .groupBy { it.linkId }
+      .flatMap {
+        it.value.filter(QuestionnaireResponse.QuestionnaireResponseItemComponent::hasAnswer)
+          .ifEmpty {
+            it.value.distinctBy { elem ->
+              elem.item.joinToString(
+                transform = QuestionnaireResponse.QuestionnaireResponseItemComponent::getLinkId
+              )
+            }
+          }
+      }
+      .onEach { it.item = distinctLinkId(it.item) }
+  }
+
+  this.item = distinctLinkId(item)
+}

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivityTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivityTest.kt
@@ -28,6 +28,7 @@ import androidx.test.core.app.ApplicationProvider
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.datacapture.QuestionnaireFragment
+import com.google.android.fhir.datacapture.validation.QuestionnaireResponseValidator.checkQuestionnaireResponse
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -39,10 +40,13 @@ import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.runTest
+import org.hl7.fhir.r4.model.CodeableConcept
+import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Encounter
 import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.Questionnaire
@@ -54,6 +58,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.Test.None
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowAlertDialog
@@ -66,6 +71,7 @@ import org.smartregister.fhircore.engine.util.AssetUtil
 import org.smartregister.fhircore.engine.util.DefaultDispatcherProvider
 import org.smartregister.fhircore.engine.util.DispatcherProvider
 import org.smartregister.fhircore.engine.util.SharedPreferencesHelper
+import org.smartregister.fhircore.engine.util.extension.distinctifyLinkId
 import org.smartregister.fhircore.engine.util.extension.encodeResourceToString
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -181,6 +187,139 @@ class QuestionnaireActivityTest : ActivityRobolectricTest() {
       FhirContext.forCached(FhirVersionEnum.R4).newJsonParser().encodeResourceToString(patient),
       result.getStringArrayList(QuestionnaireActivity.QUESTIONNAIRE_POPULATION_RESOURCES)?.get(0)
     )
+  }
+
+  @Test
+  fun testGeneratedQuestionnaireResponseWithMultipleLinkIdNotValid() = runTest {
+    val questionnaireViewModel2 = spyk(questionnaireViewModel)
+    val questionnaire =
+      Questionnaire().apply {
+        addItem().apply {
+          linkId = "page-1"
+          type = Questionnaire.QuestionnaireItemType.GROUP
+          text = "Page 1"
+          addExtension().apply {
+            url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+            setValue(
+              CodeableConcept(
+                Coding("http://hl7.org/fhir/questionnaire-item-control", "page", "Page")
+              )
+            )
+          }
+          addItem().apply {
+            linkId = "phone-info"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            text = "Phone Info"
+            addItem().apply {
+              linkId = "phone-type"
+              text = "Phone Type"
+              type = Questionnaire.QuestionnaireItemType.CHOICE
+              addAnswerOption().apply { value = StringType("Mobile") }
+              addAnswerOption().apply { value = StringType("Office") }
+            }
+
+            addItem().apply {
+              linkId = "phone-value-1"
+              text = "Phone Number"
+              type = Questionnaire.QuestionnaireItemType.STRING
+              addEnableWhen().apply {
+                question = "phone-type"
+                operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+                answer = StringType("Office")
+              }
+            }
+
+            addItem().apply {
+              linkId = "phone-value-1"
+              text = "Phone Number"
+              type = Questionnaire.QuestionnaireItemType.STRING
+              addEnableWhen().apply {
+                question = "phone-type"
+                operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+                answer = StringType("Mobile")
+              }
+            }
+          }
+        }
+      }
+    val populationIntent =
+      Intent().apply {
+        putStringArrayListExtra(
+          QuestionnaireActivity.QUESTIONNAIRE_POPULATION_RESOURCES,
+          arrayListOf(Patient().encodeResourceToString())
+        )
+      }
+    val questionnaireResponse =
+      questionnaireViewModel2.generateQuestionnaireResponse(questionnaire, populationIntent)
+    assertFailsWith<IllegalArgumentException>(
+      message = "Multiple answers for non-repeat questionnaire item phone-value-1"
+    ) { checkQuestionnaireResponse(questionnaire, questionnaireResponse) }
+  }
+
+  @Test(expected = None::class)
+  fun testGeneratedQuestionnaireResponseWithDistinctifyLinkIdValid() = runTest {
+    val questionnaireViewModel2 = spyk(questionnaireViewModel)
+    val questionnaire =
+      Questionnaire().apply {
+        addItem().apply {
+          linkId = "page-1"
+          type = Questionnaire.QuestionnaireItemType.GROUP
+          text = "Page 1"
+          addExtension().apply {
+            url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+            setValue(
+              CodeableConcept(
+                Coding("http://hl7.org/fhir/questionnaire-item-control", "page", "Page")
+              )
+            )
+          }
+          addItem().apply {
+            linkId = "phone-info"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            text = "Phone Info"
+            addItem().apply {
+              linkId = "phone-type"
+              text = "Phone Type"
+              type = Questionnaire.QuestionnaireItemType.CHOICE
+              addAnswerOption().apply { value = StringType("Mobile") }
+              addAnswerOption().apply { value = StringType("Office") }
+            }
+
+            addItem().apply {
+              linkId = "phone-value-1"
+              text = "Phone Number"
+              type = Questionnaire.QuestionnaireItemType.STRING
+              addEnableWhen().apply {
+                question = "phone-type"
+                operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+                answer = StringType("Office")
+              }
+            }
+
+            addItem().apply {
+              linkId = "phone-value-1"
+              text = "Phone Number"
+              type = Questionnaire.QuestionnaireItemType.STRING
+              addEnableWhen().apply {
+                question = "phone-type"
+                operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+                answer = StringType("Mobile")
+              }
+            }
+          }
+        }
+      }
+    val populationIntent =
+      Intent().apply {
+        putStringArrayListExtra(
+          QuestionnaireActivity.QUESTIONNAIRE_POPULATION_RESOURCES,
+          arrayListOf(Patient().encodeResourceToString())
+        )
+      }
+    val questionnaireResponse =
+      questionnaireViewModel2.generateQuestionnaireResponse(questionnaire, populationIntent)
+    questionnaireResponse.distinctifyLinkId()
+    checkQuestionnaireResponse(questionnaire, questionnaireResponse)
   }
 
   @Test


### PR DESCRIPTION
Only allow multiple 'linkId' items when they have answers

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] or Closes #[issue number]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 