### PR TITLE
Fix loading secondary resource data to Rules Engine

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesFactory.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesFactory.kt
@@ -69,7 +69,6 @@ constructor(
    * flattened in a map for ease of usage in the rule engine.
    */
   fun fireRules(rules: Rules, repositoryResourceData: RepositoryResourceData): Map<String, Any> {
-
     with(repositoryResourceData) {
       // Initialize new facts and fire rules in background
       facts =
@@ -82,11 +81,28 @@ constructor(
           relatedResourcesMap.addToFacts(this)
           relatedResourcesCountMap.addToFacts(this)
 
-          // Populate the facts map with secondary resource data
-          secondaryRepositoryResourceData?.forEach {
-            put(it.resourceRulesEngineFactId ?: it.resource.resourceType.name, it.resource)
-            relatedResourcesMap.addToFacts(this)
-            relatedResourcesCountMap.addToFacts(this)
+          // Populate the facts map with secondary resource data flatten base and related resources
+          secondaryRepositoryResourceData
+            ?.groupBy { it.resourceRulesEngineFactId ?: it.resource.resourceType.name }
+            ?.forEach { entry -> put(entry.key, entry.value.map { it.resource }) }
+
+          secondaryRepositoryResourceData?.forEach { repoResourceData ->
+            repoResourceData.relatedResourcesMap.forEach { entry ->
+              val existingRelatedResourceList = get<MutableList<Resource>>(entry.key)
+              if (existingRelatedResourceList == null) {
+                put(entry.key, mutableListOf<Resource>())
+              }
+              get<MutableList<Resource>>(entry.key).addAll(entry.value)
+            }
+
+            repoResourceData.relatedResourcesCountMap.forEach { entry ->
+              val existingRelatedResourceCountList =
+                get<MutableList<RelatedResourceCount>>(entry.key)
+              if (existingRelatedResourceCountList == null) {
+                put(entry.key, mutableListOf<RelatedResourceCount>())
+              }
+              get<MutableList<RelatedResourceCount>>(entry.key).addAll(entry.value)
+            }
           }
         }
 


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] or Closes #[issue number]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 