### PR TITLE
Fix the PinTest.testPinCellsEqualsToPinInput test 

### DIFF
--- a/android/engine/src/androidTest/java/org/smartregister/fhircore/engine/ui/components/PinTest.kt
+++ b/android/engine/src/androidTest/java/org/smartregister/fhircore/engine/ui/components/PinTest.kt
@@ -17,6 +17,7 @@
 package org.smartregister.fhircore.engine.ui.components
 
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -38,15 +39,16 @@ internal class PinTest {
         onPinEntered = { _: CharArray, _: (Boolean) -> Unit -> }
       )
     }
-    composeRule.onNodeWithTag(PIN_TEXT_FIELD_TEST_TAG).performTextInput("1234")
+    composeRule.onNodeWithTag(PIN_TEXT_FIELD_TEST_TAG).performTextInput("1")
+    composeRule.onNodeWithTag(PIN_TEXT_FIELD_TEST_TAG).performTextInput("2")
+    composeRule.onNodeWithTag(PIN_TEXT_FIELD_TEST_TAG).performTextInput("3")
+    composeRule.onNodeWithTag(PIN_TEXT_FIELD_TEST_TAG).performTextInput("4")
 
     composeRule.onAllNodesWithTag(PIN_CELL_TEST_TAG).assertCountEquals(4)
 
-    // Weird issue: Automated test fails but passes manually
-    // TO DO Investigate/Fix : Tracker issue - https://github.com/opensrp/fhircore/issues/2385
-    //    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[0].assertTextEquals("1")
-    //    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[1].assertTextEquals("2")
-    //    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[2].assertTextEquals("3")
-    //    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[3].assertTextEquals("4")
+    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[0].assertTextEquals("1")
+    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[1].assertTextEquals("2")
+    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[2].assertTextEquals("3")
+    composeRule.onAllNodesWithTag(PIN_CELL_TEXT_TEST_TAG, true)[3].assertTextEquals("4")
   }
 }


### PR DESCRIPTION
Perform individual text input to fill each pin cell

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #2385 

**Engineer Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 