### PR TITLE
Fixed reloading data when change managing entity is sucessfully completes

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesListener.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesListener.kt
@@ -65,7 +65,7 @@ abstract class RulesListener : RuleListener {
             exception,
             "${exception.localizedMessage}, consider checking for null before usage: e.g ${exception.variable} != null"
           )
-        else -> log(exception, "failed to execute rule : ${rule.name} ")
+        else -> log(exception, "Failed to execute rule : ${rule.name} ")
       }
     } else log(exception)
 

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesListener.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesListener.kt
@@ -75,9 +75,7 @@ abstract class RulesListener : RuleListener {
 
   override fun afterEvaluate(rule: Rule, facts: Facts, evaluationResult: Boolean) = Unit
 
-  fun log(exception: java.lang.Exception, message: String? = null) {
-    Timber.e(exception, message)
-  }
+  fun log(exception: java.lang.Exception, message: String? = null) = Timber.e(exception, message)
 
   fun Map<String, List<*>>.addToFacts(facts: Facts) = this.forEach { facts.put(it.key, it.value) }
 

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesListener.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/rulesengine/RulesListener.kt
@@ -65,7 +65,7 @@ abstract class RulesListener : RuleListener {
             exception,
             "${exception.localizedMessage}, consider checking for null before usage: e.g ${exception.variable} != null"
           )
-        else -> log(exception)
+        else -> log(exception, "failed to execute rule : ${rule.name} ")
       }
     } else log(exception)
 
@@ -75,7 +75,9 @@ abstract class RulesListener : RuleListener {
 
   override fun afterEvaluate(rule: Rule, facts: Facts, evaluationResult: Boolean) = Unit
 
-  fun log(exception: java.lang.Exception, message: String? = null) = Timber.e(exception, message)
+  fun log(exception: java.lang.Exception, message: String? = null) {
+    Timber.e(exception, message)
+  }
 
   fun Map<String, List<*>>.addToFacts(facts: Facts) = this.forEach { facts.put(it.key, it.value) }
 

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
@@ -101,7 +101,7 @@ class ProfileFragment : Fragment() {
             when (appEvent) {
               is AppEvent.OnSubmitQuestionnaire ->
                 handleQuestionnaireSubmission(appEvent.questionnaireSubmission)
-              is AppEvent.RefreshCache -> {}
+              else -> {}
             }
           }
           .launchIn(lifecycleScope)

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
@@ -71,7 +71,9 @@ class ProfileFragment : Fragment() {
     profileViewModel.refreshProfileDataLiveData.observe(viewLifecycleOwner) {
       viewLifecycleOwner.lifecycleScope.launch {
         if (it == true) {
-          handleRefreshLiveData()
+          with(profileFragmentArgs) {
+            profileViewModel.retrieveProfileUiState(profileId, resourceId, resourceConfig, params)
+          }
           profileViewModel.refreshProfileDataLiveData.value = null
         }
       }
@@ -107,12 +109,6 @@ class ProfileFragment : Fragment() {
           }
           .launchIn(lifecycleScope)
       }
-    }
-  }
-
-  private suspend fun handleRefreshLiveData() {
-    with(profileFragmentArgs) {
-      profileViewModel.retrieveProfileUiState(profileId, resourceId, resourceConfig, params)
     }
   }
 

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
@@ -67,6 +67,14 @@ class ProfileFragment : Fragment() {
         }
       }
     }
+    // this will be called when change managing entity is completed to reload data
+    profileViewModel.shouldReloadData.observe(viewLifecycleOwner) {
+      viewLifecycleOwner.lifecycleScope.launch {
+        if (it) {
+          handleRefreshLiveData()
+        }
+      }
+    }
 
     return ComposeView(requireContext()).apply {
       setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -93,11 +101,17 @@ class ProfileFragment : Fragment() {
             when (appEvent) {
               is AppEvent.OnSubmitQuestionnaire ->
                 handleQuestionnaireSubmission(appEvent.questionnaireSubmission)
-              else -> {}
+              is AppEvent.RefreshCache -> {}
             }
           }
           .launchIn(lifecycleScope)
       }
+    }
+  }
+
+  private suspend fun handleRefreshLiveData() {
+    with(profileFragmentArgs) {
+      profileViewModel.retrieveProfileUiState(profileId, resourceId, resourceConfig, params)
     }
   }
 

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragment.kt
@@ -67,11 +67,12 @@ class ProfileFragment : Fragment() {
         }
       }
     }
-    // this will be called when change managing entity is completed to reload data
-    profileViewModel.shouldReloadData.observe(viewLifecycleOwner) {
+
+    profileViewModel.refreshProfileDataLiveData.observe(viewLifecycleOwner) {
       viewLifecycleOwner.lifecycleScope.launch {
-        if (it) {
+        if (it == true) {
           handleRefreshLiveData()
+          profileViewModel.refreshProfileDataLiveData.value = null
         }
       }
     }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileViewModel.kt
@@ -71,6 +71,7 @@ constructor(
   val resourceDataRulesExecutor: ResourceDataRulesExecutor
 ) : ViewModel() {
 
+  val refreshProfileDataLiveData = MutableLiveData<Boolean?>(null)
   val profileUiState = mutableStateOf(ProfileUiState())
   val applicationConfiguration: ApplicationConfiguration by lazy {
     configurationRegistry.retrieveConfiguration(ConfigType.Application)
@@ -78,10 +79,9 @@ constructor(
   private val _snackBarStateFlow = MutableSharedFlow<SnackBarMessageConfig>()
   val snackBarStateFlow: SharedFlow<SnackBarMessageConfig> = _snackBarStateFlow.asSharedFlow()
   private lateinit var profileConfiguration: ProfileConfiguration
+
   private val listResourceDataStateMap =
     mutableStateMapOf<String, SnapshotStateList<ResourceData>>()
-
-  val shouldReloadData = MutableLiveData<Boolean>()
 
   /**
    * This function retrieves an image that was synced from the backend as a [Binary] resource, the
@@ -195,7 +195,7 @@ constructor(
                   actionLabel = event.context.getString(R.string.ok)
                 )
             )
-            shouldReloadData.value = true
+            refreshProfileDataLiveData.value = true
           }
         }
       }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/profile/ProfileViewModel.kt
@@ -19,6 +19,7 @@ package org.smartregister.fhircore.quest.ui.profile
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.fhir.db.ResourceNotFoundException
@@ -79,6 +80,8 @@ constructor(
   private lateinit var profileConfiguration: ProfileConfiguration
   private val listResourceDataStateMap =
     mutableStateMapOf<String, SnapshotStateList<ResourceData>>()
+
+  val shouldReloadData = MutableLiveData<Boolean>()
 
   /**
    * This function retrieves an image that was synced from the backend as a [Binary] resource, the
@@ -192,6 +195,7 @@ constructor(
                   actionLabel = event.context.getString(R.string.ok)
                 )
             )
+            shouldReloadData.value = true
           }
         }
       }

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragmentTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/profile/ProfileFragmentTest.kt
@@ -22,6 +22,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.commitNow
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -31,8 +32,10 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.ResourceType
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -40,6 +43,7 @@ import org.junit.Test
 import org.robolectric.Robolectric
 import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry
 import org.smartregister.fhircore.engine.configuration.QuestionnaireConfig
+import org.smartregister.fhircore.engine.configuration.profile.ManagingEntityConfig
 import org.smartregister.fhircore.engine.data.local.register.RegisterRepository
 import org.smartregister.fhircore.engine.domain.model.ActionParameter
 import org.smartregister.fhircore.engine.domain.model.ActionParameterType
@@ -51,6 +55,7 @@ import org.smartregister.fhircore.quest.app.fakes.Faker
 import org.smartregister.fhircore.quest.navigation.NavigationArg
 import org.smartregister.fhircore.quest.robolectric.RobolectricTest
 import org.smartregister.fhircore.quest.ui.main.AppMainActivity
+import org.smartregister.fhircore.quest.ui.profile.model.EligibleManagingEntity
 import org.smartregister.fhircore.quest.ui.shared.models.QuestionnaireSubmission
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -68,9 +73,9 @@ class ProfileFragmentTest : RobolectricTest() {
   val profileViewModel =
     spyk(
       ProfileViewModel(
-        mockk(),
+        registerRepository,
         configurationRegistry = configurationRegistry,
-        mockk(),
+        this.coroutineTestRule.testDispatcherProvider,
         mockk(),
         mockk()
       )
@@ -156,5 +161,40 @@ class ProfileFragmentTest : RobolectricTest() {
       )
     }
     coVerify { profileViewModel.emitSnackBarState(snackBarMessageConfig) }
+  }
+
+  @Test
+  fun testReloadingProfileUIStateWhenChangeManagingEntityCompletes() {
+
+    coEvery { profileViewModel.retrieveProfileUiState(any(), any(), any(), any()) } just runs
+
+    coEvery { registerRepository.changeManagingEntity(any(), any(), any()) } just runs
+
+    coEvery { profileViewModel.emitSnackBarState(any()) } just runs
+
+    profileViewModel.onEvent(
+      ProfileEvent.OnChangeManagingEntity(
+        ApplicationProvider.getApplicationContext(),
+        eligibleManagingEntity =
+          EligibleManagingEntity("groupId", "newId", memberInfo = "James Doe"),
+        managingEntityConfig =
+          ManagingEntityConfig(
+            eligibilityCriteriaFhirPathExpression = "Patient.active",
+            resourceType = ResourceType.Patient,
+            nameFhirPathExpression = "Patient.name.given"
+          )
+      )
+    )
+
+    coVerify { registerRepository.changeManagingEntity(any(), any(), any()) }
+
+    coVerify {
+      profileViewModel.retrieveProfileUiState(
+        profileId = "defaultProfile",
+        resourceId = "sampleId",
+        any(),
+        any()
+      )
+    }
   }
 }


### PR DESCRIPTION

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes - https://github.com/opensrp/fhir-resources/issues/1742

Testing reference

https://github.com/opensrp/fhircore/assets/35099184/3664e3f9-4898-42ba-a177-b32e55bde946


**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 