### PR TITLE
Fix change HH head breaking if a HH head is not already assigned

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/data/local/DefaultRepository.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/data/local/DefaultRepository.kt
@@ -227,7 +227,9 @@ constructor(
     val group = fhirEngine.get<Group>(groupId)
     if (managingEntityConfig?.resourceType == ResourceType.Patient) {
       val relatedPerson =
-        if (group.managingEntity.reference != null) {
+        if (group.managingEntity.reference != null &&
+            group.managingEntity.reference.startsWith(ResourceType.RelatedPerson.name)
+        ) {
           fhirEngine.get(group.managingEntity.reference.extractLogicalIdUuid())
         } else {
           RelatedPerson().apply { id = UUID.randomUUID().toString() }

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/DefaultRepositoryTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/data/local/DefaultRepositoryTest.kt
@@ -54,6 +54,7 @@ import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.Enumerations
 import org.hl7.fhir.r4.model.Group
 import org.hl7.fhir.r4.model.HumanName
+import org.hl7.fhir.r4.model.Organization
 import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.Procedure
 import org.hl7.fhir.r4.model.Reference
@@ -459,6 +460,82 @@ class DefaultRepositoryTest : RobolectricTest() {
     coVerify { fhirEngine.get<Group>("73847") }
 
     coVerify { defaultRepositorySpy.addOrUpdate(resource = relatedPerson) }
+  }
+
+  @Test
+  fun changeManagingEntityShouldVerifyFhirEngineCallsEvenWithAnOrganizationAsTheCurrentManagingEntity() {
+
+    val patient =
+      Patient().apply {
+        id = "54321"
+        addName().apply {
+          addGiven("Sam")
+          family = "Smith"
+        }
+        addTelecom().apply { value = "ssmith@mail.com" }
+        addAddress().apply {
+          district = "Mawar"
+          city = "Jakarta"
+        }
+        gender = Enumerations.AdministrativeGender.MALE
+      }
+    val relatedPerson =
+      RelatedPerson().apply {
+        active = true
+        name = patient.name
+        birthDate = patient.birthDate
+        telecom = patient.telecom
+        address = patient.address
+        gender = patient.gender
+        this.patient = patient.asReference()
+        id = "testRelatedPersonId"
+      }
+
+    val organization =
+      Organization().apply {
+        id = "12983"
+        name = "Test Organization"
+      }
+
+    val defaultRepositorySpy = spyk(defaultRepository)
+
+    coEvery { fhirEngine.get<Patient>("54321") } returns patient
+    coEvery { fhirEngine.get<Organization>("12983") } returns organization
+    coEvery { fhirEngine.get<RelatedPerson>(any()) } returns relatedPerson
+    coEvery { fhirEngine.create(any()) } returns listOf()
+
+    val group =
+      Group().apply {
+        id = "73847"
+        managingEntity = Reference("Organization/12983")
+        managingEntity.id = "33292"
+      }
+    coEvery { fhirEngine.get<Group>("73847") } returns group
+
+    coEvery { fhirEngine.update(any()) } just runs
+
+    coEvery { fhirEngine.get(relatedPerson.resourceType, any()) } answers { relatedPerson }
+    runBlocking {
+      defaultRepositorySpy.changeManagingEntity(
+        newManagingEntityId = "54321",
+        groupId = "73847",
+        ManagingEntityConfig(
+          resourceType = ResourceType.Patient,
+          relationshipCode =
+            Code().apply {
+              system = "http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype"
+              code = "99990006"
+              display = "Family Head"
+            }
+        )
+      )
+    }
+
+    coVerify { fhirEngine.get<Patient>("54321") }
+
+    coVerify { fhirEngine.get<Group>("73847") }
+
+    coVerify(inverse = true) { defaultRepositorySpy.addOrUpdate(resource = any()) }
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes https://github.com/opensrp/fhir-resources/issues/2001

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 