### PR TITLE
:bug: Remove the minus 1 day condition for tasks to be marked as ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calculate DUE dates for dependent Tasks
 - Triggering QuestionnaireResponse extraction for Questionnaires closed via a Confirm Dialog
 - Fix the OVERDUE service status setting on the `RulesFactory#generateTaskServiceStatus()`
+- `Task.status` for tasks created today and DUE today not update to `ready`
 
 ### Changed
 - Refactored how the related resources SELECT and COUNT queries search results are represented. 

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/task/FhirTaskPlanWorker.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/task/FhirTaskPlanWorker.kt
@@ -72,7 +72,7 @@ constructor(
             Task.PERIOD,
             {
               prefix = ParamPrefixEnum.LESSTHAN_OR_EQUALS
-              value = of(DateTimeType(Date().plusDays(-1)))
+              value = of(DateTimeType(Date()))
             }
           )
         }

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/task/FhirTaskPlanWorker.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/task/FhirTaskPlanWorker.kt
@@ -38,7 +38,6 @@ import org.smartregister.fhircore.engine.util.SharedPreferencesHelper
 import org.smartregister.fhircore.engine.util.extension.executionStartIsBeforeOrToday
 import org.smartregister.fhircore.engine.util.extension.extractId
 import org.smartregister.fhircore.engine.util.extension.isIn
-import org.smartregister.fhircore.engine.util.extension.plusDays
 import org.smartregister.fhircore.engine.util.extension.toCoding
 import timber.log.Timber
 

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/task/FhirTaskPlanWorkerTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/task/FhirTaskPlanWorkerTest.kt
@@ -191,7 +191,7 @@ class FhirTaskPlanWorkerTest : RobolectricTest() {
     Assert.assertEquals(result, (ListenableWorker.Result.success()))
     Assert.assertEquals(Task.TaskStatus.REQUESTED, task.status)
   }
-  
+
   @Test
   fun `FhirTaskPlanWorker doWork set the correct status when start date is 2 years ago`() {
     val task =


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #https://github.com/opensrp/fhir-resources/issues/1998

**Engineer Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [x] I have added any strings visible on UI components to the `strings.xml` file
- [x] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [x] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [x] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [x] I have verified any strings visible on UI components are in the `strings.xml` file
- [x] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [x] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [x] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 