### PR TITLE
Catch non-HttpException errors when fetching keycloak user

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/LoginViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/LoginViewModel.kt
@@ -29,6 +29,7 @@ import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.sentry.Sentry
 import io.sentry.protocol.User
+import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -265,6 +266,15 @@ constructor(
       }
     } catch (httpException: HttpException) {
       onFetchUserInfo(Result.failure(httpException))
+    } catch (unknownHostException: UnknownHostException) {
+      onFetchUserInfo(Result.failure(unknownHostException))
+      Timber.e(unknownHostException, "An error occurred fetching the practitioner details")
+    } catch (socketTimeoutException: SocketTimeoutException) {
+      onFetchUserInfo(Result.failure(socketTimeoutException))
+      Timber.e(socketTimeoutException, "An error occurred fetching the practitioner details")
+    } catch (exception: Exception) {
+      onFetchUserInfo(Result.failure(exception))
+      Timber.e(exception, "An error occurred fetching the practitioner details")
     }
   }
 

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/LoginViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/LoginViewModel.kt
@@ -258,6 +258,15 @@ constructor(
         } catch (httpException: HttpException) {
           onFetchPractitioner(Result.failure(httpException))
           Timber.e(httpException.response()?.errorBody()?.charStream()?.readText())
+        } catch (unknownHostException: UnknownHostException) {
+          onFetchPractitioner(Result.failure(unknownHostException))
+          Timber.e(unknownHostException, "An error occurred fetching the practitioner details")
+        } catch (socketTimeoutException: SocketTimeoutException) {
+          onFetchPractitioner(Result.failure(socketTimeoutException))
+          Timber.e(socketTimeoutException, "An error occurred fetching the practitioner details")
+        } catch (exception: Exception) {
+          onFetchPractitioner(Result.failure(exception))
+          Timber.e(exception, "An error occurred fetching the practitioner details")
         }
       } else {
         onFetchPractitioner(


### PR DESCRIPTION
Catch non-HttpException errors when fetching keycloak user

Fixes #2534 

**Engineer Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [x] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [x] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 