### PR TITLE
Add CompoundText visibility property check

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/components/CompoundText.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/components/CompoundText.kt
@@ -64,65 +64,67 @@ fun CompoundText(
   resourceData: ResourceData,
   navController: NavController,
 ) {
-  FlowRow(
-    modifier =
-      modifier
-        .conditional(compoundTextProperties.fillMaxWidth, { fillMaxWidth() })
-        .conditional(compoundTextProperties.fillMaxHeight, { fillMaxHeight() })
-        .padding(
-          horizontal = compoundTextProperties.padding.dp,
-          vertical = compoundTextProperties.padding.div(2).dp,
-        )
-        .background(compoundTextProperties.backgroundColor.parseColor()),
-  ) {
-    if (!compoundTextProperties.primaryText.isNullOrEmpty()) {
-      CompoundTextPart(
-        modifier = modifier,
-        viewAlignment = compoundTextProperties.alignment,
-        text = compoundTextProperties.primaryText!!,
-        textCase = compoundTextProperties.textCase,
-        maxLines = compoundTextProperties.maxLines,
-        textColor = compoundTextProperties.primaryTextColor,
-        backgroundColor = compoundTextProperties.primaryTextBackgroundColor,
-        borderRadius = compoundTextProperties.borderRadius,
-        fontSize = compoundTextProperties.fontSize,
-        textFontWeight = compoundTextProperties.primaryTextFontWeight,
-        clickable = compoundTextProperties.clickable,
-        actions = compoundTextProperties.primaryTextActions,
-        resourceData = resourceData,
-        navController = navController,
-        overflow = compoundTextProperties.overflow,
-      )
-    }
-    // Separate the primary and secondary text
-    if (!compoundTextProperties.separator.isNullOrEmpty()) {
-      Box(contentAlignment = Alignment.Center, modifier = modifier.padding(horizontal = 6.dp)) {
-        Text(
-          text = compoundTextProperties.separator!!,
-          fontSize = compoundTextProperties.fontSize.sp,
-          color = DefaultColor,
-          textAlign = TextAlign.Center,
+  if (compoundTextProperties.visible.toBoolean()) {
+    FlowRow(
+      modifier =
+        modifier
+          .conditional(compoundTextProperties.fillMaxWidth, { fillMaxWidth() })
+          .conditional(compoundTextProperties.fillMaxHeight, { fillMaxHeight() })
+          .padding(
+            horizontal = compoundTextProperties.padding.dp,
+            vertical = compoundTextProperties.padding.div(2).dp,
+          )
+          .background(compoundTextProperties.backgroundColor.parseColor()),
+    ) {
+      if (!compoundTextProperties.primaryText.isNullOrEmpty()) {
+        CompoundTextPart(
+          modifier = modifier,
+          viewAlignment = compoundTextProperties.alignment,
+          text = compoundTextProperties.primaryText!!,
+          textCase = compoundTextProperties.textCase,
+          maxLines = compoundTextProperties.maxLines,
+          textColor = compoundTextProperties.primaryTextColor,
+          backgroundColor = compoundTextProperties.primaryTextBackgroundColor,
+          borderRadius = compoundTextProperties.borderRadius,
+          fontSize = compoundTextProperties.fontSize,
+          textFontWeight = compoundTextProperties.primaryTextFontWeight,
+          clickable = compoundTextProperties.clickable,
+          actions = compoundTextProperties.primaryTextActions,
+          resourceData = resourceData,
+          navController = navController,
+          overflow = compoundTextProperties.overflow,
         )
       }
-    }
-    if (!compoundTextProperties.secondaryText.isNullOrEmpty()) {
-      CompoundTextPart(
-        modifier = modifier,
-        viewAlignment = compoundTextProperties.alignment,
-        text = compoundTextProperties.secondaryText!!,
-        textCase = compoundTextProperties.textCase,
-        maxLines = compoundTextProperties.maxLines,
-        textColor = compoundTextProperties.secondaryTextColor,
-        backgroundColor = compoundTextProperties.secondaryTextBackgroundColor,
-        borderRadius = compoundTextProperties.borderRadius,
-        fontSize = compoundTextProperties.fontSize,
-        textFontWeight = compoundTextProperties.secondaryTextFontWeight,
-        clickable = compoundTextProperties.clickable,
-        actions = compoundTextProperties.secondaryTextActions,
-        navController = navController,
-        resourceData = resourceData,
-        overflow = compoundTextProperties.overflow,
-      )
+      // Separate the primary and secondary text
+      if (!compoundTextProperties.separator.isNullOrEmpty()) {
+        Box(contentAlignment = Alignment.Center, modifier = modifier.padding(horizontal = 6.dp)) {
+          Text(
+            text = compoundTextProperties.separator!!,
+            fontSize = compoundTextProperties.fontSize.sp,
+            color = DefaultColor,
+            textAlign = TextAlign.Center,
+          )
+        }
+      }
+      if (!compoundTextProperties.secondaryText.isNullOrEmpty()) {
+        CompoundTextPart(
+          modifier = modifier,
+          viewAlignment = compoundTextProperties.alignment,
+          text = compoundTextProperties.secondaryText!!,
+          textCase = compoundTextProperties.textCase,
+          maxLines = compoundTextProperties.maxLines,
+          textColor = compoundTextProperties.secondaryTextColor,
+          backgroundColor = compoundTextProperties.secondaryTextBackgroundColor,
+          borderRadius = compoundTextProperties.borderRadius,
+          fontSize = compoundTextProperties.fontSize,
+          textFontWeight = compoundTextProperties.secondaryTextFontWeight,
+          clickable = compoundTextProperties.clickable,
+          actions = compoundTextProperties.secondaryTextActions,
+          navController = navController,
+          resourceData = resourceData,
+          overflow = compoundTextProperties.overflow,
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Currently, property `visible` is not being evaluated for `CompoundText`. This is because the visibility check is done in `ViewGenerator.kt` which is not always called when creating some views, esp. when created from other widgets such as `ServiceCard`, etc.

This fix adds a check for visibility before rendering the CompoundText.

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 