### PR TITLE
remove writing fhir readme and name category directly

### DIFF
--- a/docs/engineering/android-app/writing-fhir/_category_.yml
+++ b/docs/engineering/android-app/writing-fhir/_category_.yml
@@ -1,0 +1,1 @@
+label: 'Writing FHIR'

--- a/docs/engineering/android-app/writing-fhir/readme.mdx
+++ b/docs/engineering/android-app/writing-fhir/readme.mdx
@@ -1,5 +1,0 @@
-# Writing FHIR
-
-- [Clinical Query Language](advanced-fhir/cql)
-- [Smart Vaccination Certifications](advanced-fhir/smart-vax-certs)
-- [FHIR Path](https://github.com/opensrp/fhircore/blob/main/docs/advanced-fhir/fhir_path.mdx)


### PR DESCRIPTION
Fixes broken links on the current writing fhir page