### PR TITLE
passing empty bundle instead of null to trigger the careplan when we don't have any bundle resource

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -221,7 +221,7 @@ constructor(
         val subject =
           loadResource(ResourceType.valueOf(subjectIdType.resourceType), subjectIdType.idPart)
 
-        if (subject != null && bundle != null) {
+        if (subject != null) {
           val newBundle = bundle.copyBundle(currentQuestionnaireResponse)
           generateCarePlan(
             subject = subject,
@@ -246,14 +246,14 @@ constructor(
       softDeleteResources(questionnaireConfig)
 
       val idTypes =
-        bundle?.entry?.map { IdType(it.resource.resourceType.name, it.resource.logicalId) }
+        bundle.entry?.map { IdType(it.resource.resourceType.name, it.resource.logicalId) }
           ?: emptyList()
       onSuccessfulSubmission(idTypes, currentQuestionnaireResponse)
     }
   }
 
   suspend fun saveExtractedResources(
-    bundle: Bundle?,
+    bundle: Bundle,
     questionnaire: Questionnaire,
     questionnaireConfig: QuestionnaireConfig,
     currentQuestionnaireResponse: QuestionnaireResponse,
@@ -270,7 +270,7 @@ constructor(
         date = extractionDate
       }
 
-    bundle?.entry?.forEach { bundleEntryComponent ->
+    bundle.entry?.forEach { bundleEntryComponent ->
       bundleEntryComponent.resource?.run {
         applyResourceMetadata()
         val subjectType = questionnaireSubjectType(questionnaire, questionnaireConfig)
@@ -366,7 +366,7 @@ constructor(
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
     context: Context,
-  ): Bundle? =
+  ): Bundle =
     kotlin
       .runCatching {
         if (extractByStructureMap) {
@@ -407,7 +407,7 @@ constructor(
           }
         }
       }
-      .getOrDefault(null)
+      .getOrDefault(Bundle())
 
   /**
    * This function saves [QuestionnaireResponse] as draft if any of the [QuestionnaireResponse.item]

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelTest.kt
@@ -361,8 +361,8 @@ class QuestionnaireViewModelTest : RobolectricTest() {
         context = context,
       )
     Assert.assertNotNull(bundle)
-    Assert.assertTrue(bundle?.entryFirstRep?.resource is Patient)
-    Assert.assertEquals(patient.id, bundle?.entryFirstRep?.resource?.id)
+    Assert.assertTrue(bundle.entryFirstRep?.resource is Patient)
+    Assert.assertEquals(patient.id, bundle.entryFirstRep?.resource?.id)
     unmockkObject(ResourceMapper)
   }
 
@@ -382,8 +382,8 @@ class QuestionnaireViewModelTest : RobolectricTest() {
         context = context,
       )
     Assert.assertNotNull(bundle)
-    Assert.assertTrue(bundle?.entryFirstRep?.resource is Patient)
-    Assert.assertEquals(patient.id, bundle?.entryFirstRep?.resource?.id)
+    Assert.assertTrue(bundle.entryFirstRep?.resource is Patient)
+    Assert.assertEquals(patient.id, bundle.entryFirstRep?.resource?.id)
     unmockkObject(ResourceMapper)
   }
 


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] or Closes #[issue number]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [x] I have verified any strings visible on UI components are in the `strings.xml` file
- [x] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [x] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 