### PR TITLE
[Quest/Malawi Core] Filter guardian task using the meta tag

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/ConfigurationRegistry.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/ConfigurationRegistry.kt
@@ -301,6 +301,7 @@ constructor(
     const val ID = "_id"
     const val COUNT = "count"
     const val DEFAULT_COUNT = "100"
+    const val DEFAULT_TASK_FILTER_TAG_META_CODING_SYSTEM = "https://d-tree.org/fhir/task-filter-tag"
     const val TYPE_REFERENCE_DELIMITER = "/"
   }
 }

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/ApplicationConfiguration.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/ApplicationConfiguration.kt
@@ -19,6 +19,7 @@ package org.smartregister.fhircore.engine.configuration.app
 import kotlinx.serialization.Serializable
 import org.smartregister.fhircore.engine.configuration.Configuration
 import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry
+import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry.Companion.DEFAULT_TASK_FILTER_TAG_META_CODING_SYSTEM
 
 @Serializable
 data class ApplicationConfiguration(
@@ -32,7 +33,7 @@ data class ApplicationConfiguration(
   var appLogoIconResourceFile: String = "ic_default_logo",
   var patientTypeFilterTagViaMetaCodingSystem: String = "",
   var count: String = ConfigurationRegistry.DEFAULT_COUNT,
-  var taskFilterTagViaMetaCodingSystem: String = ""
+  var taskFilterTagViaMetaCodingSystem: String = DEFAULT_TASK_FILTER_TAG_META_CODING_SYSTEM
 ) : Configuration
 
 /**

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/ApplicationConfiguration.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/ApplicationConfiguration.kt
@@ -31,7 +31,8 @@ data class ApplicationConfiguration(
   var applicationName: String = "",
   var appLogoIconResourceFile: String = "ic_default_logo",
   var patientTypeFilterTagViaMetaCodingSystem: String = "",
-  var count: String = ConfigurationRegistry.DEFAULT_COUNT
+  var count: String = ConfigurationRegistry.DEFAULT_COUNT,
+  var taskFilterTagViaMetaCodingSystem: String = ""
 ) : Configuration
 
 /**
@@ -57,7 +58,8 @@ fun applicationConfigurationOf(
   applicationName: String = "",
   appLogoIconResourceFile: String = "",
   patientTypeFilterTagViaMetaCodingSystem: String = "",
-  count: String = ConfigurationRegistry.DEFAULT_COUNT
+  count: String = ConfigurationRegistry.DEFAULT_COUNT,
+  taskFilterTagViaMetaCodingSystem: String = ""
 ): ApplicationConfiguration =
   ApplicationConfiguration(
     appId = appId,
@@ -69,5 +71,6 @@ fun applicationConfigurationOf(
     applicationName = applicationName,
     appLogoIconResourceFile = appLogoIconResourceFile,
     patientTypeFilterTagViaMetaCodingSystem = patientTypeFilterTagViaMetaCodingSystem,
-    count = count
+    count = count,
+    taskFilterTagViaMetaCodingSystem = taskFilterTagViaMetaCodingSystem
   )

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/configuration/app/ApplicationConfigurationTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/configuration/app/ApplicationConfigurationTest.kt
@@ -33,7 +33,8 @@ class ApplicationConfigurationTest {
         applicationName = "Test App",
         appLogoIconResourceFile = "ic_launcher",
         patientTypeFilterTagViaMetaCodingSystem = "test-filter-tag",
-        count = "100"
+        count = "100",
+        taskFilterTagViaMetaCodingSystem = "task-filter-tag"
       )
     Assert.assertEquals("ancApp", applicationConfiguration.appId)
     Assert.assertEquals("classification", applicationConfiguration.classification)
@@ -46,6 +47,10 @@ class ApplicationConfigurationTest {
       applicationConfiguration.patientTypeFilterTagViaMetaCodingSystem
     )
     Assert.assertEquals("100", applicationConfiguration.count)
+    Assert.assertEquals(
+      "task-filter-tag",
+      applicationConfiguration.taskFilterTagViaMetaCodingSystem
+    )
   }
 
   @Test
@@ -60,7 +65,8 @@ class ApplicationConfigurationTest {
         applicationName = "Test App",
         appLogoIconResourceFile = "ic_launcher",
         patientTypeFilterTagViaMetaCodingSystem = "test-filter-tag",
-        count = "100"
+        count = "100",
+        taskFilterTagViaMetaCodingSystem = "task-filter-tag"
       )
     Assert.assertEquals("ancApp", applicationConfiguration.appId)
     Assert.assertEquals("classification", applicationConfiguration.classification)
@@ -73,5 +79,9 @@ class ApplicationConfigurationTest {
       applicationConfiguration.patientTypeFilterTagViaMetaCodingSystem
     )
     Assert.assertEquals("100", applicationConfiguration.count)
+    Assert.assertEquals(
+      "task-filter-tag",
+      applicationConfiguration.taskFilterTagViaMetaCodingSystem
+    )
   }
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
@@ -17,6 +17,7 @@
 package org.smartregister.fhircore.quest.ui.patient.profile
 
 import android.app.Activity
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.os.bundleOf
@@ -108,27 +109,6 @@ constructor(
 
   private val isClientVisit: MutableState<Boolean> = mutableStateOf(true)
 
-  fun completedTask(value: String) {
-    patientProfileData?.let { data ->
-      if (data is ProfileData.HivProfileData) {
-        val patientData =
-          data.copy(
-            tasks =
-              data.tasks.map { task ->
-                if (task.reasonReference.extractId() == value) {
-                  task.status = Task.TaskStatus.COMPLETED
-                  task
-                } else task
-              }
-          )
-        _patientProfileViewDataFlow.value =
-          profileViewDataMapper.transformInputToOutputModel(patientData) as
-            ProfileViewData.PatientProfileViewData
-        patientProfileData = patientData
-      }
-    }
-  }
-
   init {
     syncBroadcaster.registerSyncListener(
       object : OnSyncListener {
@@ -189,7 +169,7 @@ constructor(
         hivPatientProfileData.copy(
           tasks =
             hivPatientProfileData.tasks.filter {
-              it.isGuardianVisit(applicationConfiguration.patientTypeFilterTagViaMetaCodingSystem)
+              it.isGuardianVisit(applicationConfiguration.taskFilterTagViaMetaCodingSystem)
             }
         )
       _patientProfileViewDataFlow.value =

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/profile/PatientProfileViewModel.kt
@@ -17,7 +17,6 @@
 package org.smartregister.fhircore.quest.ui.patient.profile
 
 import android.app.Activity
-import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.os.bundleOf
@@ -52,7 +51,6 @@ import org.smartregister.fhircore.engine.sync.SyncBroadcaster
 import org.smartregister.fhircore.engine.ui.questionnaire.QuestionnaireActivity
 import org.smartregister.fhircore.engine.ui.questionnaire.QuestionnaireType
 import org.smartregister.fhircore.engine.util.extension.asReference
-import org.smartregister.fhircore.engine.util.extension.extractId
 import org.smartregister.fhircore.engine.util.extension.isGuardianVisit
 import org.smartregister.fhircore.quest.R
 import org.smartregister.fhircore.quest.data.patient.model.PatientPagingSourceState


### PR DESCRIPTION
## Description
Filter guardian task using the meta tag


**Additional context**
There has been an addition to the Binary/app-config-saa-prod
```
{
  "taskFilterTagViaMetaCodingSystem": "https://d-tree.org/fhir/task-filter-tag"
}
```

For guardian visits, the meta tag looks like  below

```
  {
    "system": "https://d-tree.org/fhir/task-filter-tag",
    "code": "guardian-visit"
  }
```

