### PR TITLE
[MWCore] - Fix crash occurring on authentication fails after initial log-in

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/auth/AccountAuthenticator.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/auth/AccountAuthenticator.kt
@@ -28,14 +28,12 @@ import android.os.Handler
 import android.os.Looper
 import androidx.core.os.bundleOf
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.net.UnknownHostException
 import java.util.Locale
 import javax.inject.Inject
 import org.smartregister.fhircore.engine.data.remote.shared.TokenAuthenticator
 import org.smartregister.fhircore.engine.data.remote.shared.TokenAuthenticator.Companion.AUTH_TOKEN_TYPE
 import org.smartregister.fhircore.engine.ui.login.LoginActivity
 import org.smartregister.fhircore.engine.util.SecureSharedPreference
-import retrofit2.HttpException
 import timber.log.Timber
 
 class AccountAuthenticator
@@ -88,10 +86,7 @@ constructor(
             tokenAuthenticator.refreshToken(refreshToken)
           } catch (ex: Exception) {
             Timber.e(ex)
-            when (ex) {
-              is HttpException, is UnknownHostException -> ""
-              else -> throw ex
-            }
+            "" // Set to EMPTY, so as to redirect to log in screen, and try again
           }
       }
     }

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/di/CoreModule.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/di/CoreModule.kt
@@ -34,6 +34,7 @@ import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry
 import org.smartregister.fhircore.engine.configuration.app.ConfigService
 import org.smartregister.fhircore.engine.data.local.DefaultRepository
 import org.smartregister.fhircore.engine.data.local.register.dao.HivRegisterDao
+import org.smartregister.fhircore.engine.data.remote.shared.TokenAuthenticator
 import org.smartregister.fhircore.engine.domain.repository.PatientDao
 import org.smartregister.fhircore.engine.sync.SyncBroadcaster
 import org.smartregister.fhircore.engine.trace.PerformanceReporter
@@ -51,6 +52,7 @@ class CoreModule {
     configService: ConfigService,
     fhirEngine: FhirEngine,
     tracer: PerformanceReporter,
+    tokenAuthenticator: TokenAuthenticator,
     sharedPreferencesHelper: SharedPreferencesHelper
   ) =
     SyncBroadcaster(
@@ -59,6 +61,7 @@ class CoreModule {
       fhirEngine = fhirEngine,
       appContext = context,
       tracer = tracer,
+      tokenAuthenticator = tokenAuthenticator,
       sharedPreferencesHelper = sharedPreferencesHelper
     )
 

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/AccountAuthenticatorTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/AccountAuthenticatorTest.kt
@@ -323,7 +323,6 @@ class AccountAuthenticatorTest : RobolectricTest() {
     Assert.assertFalse(authTokenBundle.containsKey(KEY_AUTHTOKEN))
   }
 
-  @Test(expected = RuntimeException::class)
   fun testGetBundleWithoutAuthInfoWhenCaughtUnknownHost() {
     every { tokenAuthenticator.isTokenActive(any()) } returns false
     val account = spyk(Account("newAccName", "newAccType"))
@@ -333,7 +332,11 @@ class AccountAuthenticatorTest : RobolectricTest() {
     every { accountManager.getPassword(account) } returns refreshToken
     every { tokenAuthenticator.refreshToken(refreshToken) } throws RuntimeException()
 
-    accountAuthenticator.getAuthToken(null, account, authTokenType, bundleOf())
+    val authTokenBundle =
+      accountAuthenticator.getAuthToken(null, account, authTokenType, bundleOf())
+    Assert.assertNotNull(authTokenBundle)
+    Assert.assertFalse(authTokenBundle.containsKey(KEY_AUTHTOKEN))
+    Assert.assertTrue(authTokenBundle.containsKey(KEY_INTENT)) // contains intent to re-login
   }
 
   @Test

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/TokenAuthenticatorTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/TokenAuthenticatorTest.kt
@@ -462,6 +462,7 @@ class TokenAuthenticatorTest : RobolectricTest() {
     every { accountManager.peekAuthToken(account, TokenAuthenticator.AUTH_TOKEN_TYPE) } returns
       token
     every { tokenAuthenticator.isTokenActive(any()) } returns false
+    every { accountManager.invalidateAuthToken(any(), any()) } just runs
 
     Assert.assertFalse(tokenAuthenticator.sessionActive())
   }

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/userprofile/UserProfileViewModelTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/ui/userprofile/UserProfileViewModelTest.kt
@@ -43,6 +43,7 @@ import org.smartregister.fhircore.engine.auth.AccountAuthenticator
 import org.smartregister.fhircore.engine.configuration.app.ConfigService
 import org.smartregister.fhircore.engine.data.remote.fhir.resource.FhirResourceDataSource
 import org.smartregister.fhircore.engine.data.remote.fhir.resource.FhirResourceService
+import org.smartregister.fhircore.engine.data.remote.shared.TokenAuthenticator
 import org.smartregister.fhircore.engine.domain.model.Language
 import org.smartregister.fhircore.engine.robolectric.RobolectricTest
 import org.smartregister.fhircore.engine.rule.CoroutineTestRule
@@ -63,6 +64,7 @@ class UserProfileViewModelTest : RobolectricTest() {
   lateinit var sharedPreferencesHelper: SharedPreferencesHelper
 
   @BindValue var configurationRegistry = Faker.buildTestConfigurationRegistry()
+  var tokenAuthenticator: TokenAuthenticator = mockk()
 
   private lateinit var configService: ConfigService
 
@@ -81,6 +83,8 @@ class UserProfileViewModelTest : RobolectricTest() {
     configService = AppConfigService(context = context)
     fhirResourceDataSource = spyk(FhirResourceDataSource(resourceService))
 
+    every { tokenAuthenticator.sessionActive() } returns true
+
     syncBroadcaster =
       SyncBroadcaster(
         configurationRegistry,
@@ -90,6 +94,7 @@ class UserProfileViewModelTest : RobolectricTest() {
         dispatcherProvider = CoroutineTestRule().testDispatcherProvider,
         appContext = context,
         tracer = mockk(),
+        tokenAuthenticator = tokenAuthenticator,
         sharedPreferencesHelper = sharedPreferencesHelper
       )
     userProfileViewModel =


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes crash occurring in cases of authentication fail after initial login by redirecting to log in in case of any error, and always checking a user's authorization everytime before running a sync

**Engineer Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [x] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [x] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
