### PR TITLE
 Remove the requirement on supplying OAuth Client Secrets

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/AuthConfiguration.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/AuthConfiguration.kt
@@ -21,7 +21,6 @@ data class AuthConfiguration(
   var oauthServerBaseUrl: String,
   var fhirServerBaseUrl: String,
   var clientId: String,
-  var clientSecret: String,
   var accountType: String,
   var scope: String = "openid",
 )

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/data/remote/auth/OAuthService.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/data/remote/auth/OAuthService.kt
@@ -34,7 +34,6 @@ interface OAuthService {
   @POST("protocol/openid-connect/logout")
   suspend fun logout(
     @Field("client_id") clientId: String,
-    @Field("client_secret") clientSecret: String,
     @Field("refresh_token") refreshToken: String,
   ): Response<ResponseBody>
 }

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/data/remote/shared/TokenAuthenticator.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/data/remote/shared/TokenAuthenticator.kt
@@ -146,7 +146,6 @@ constructor(
     mutableMapOf(
       GRANT_TYPE to grantType,
       CLIENT_ID to authConfiguration.clientId,
-      CLIENT_SECRET to authConfiguration.clientSecret,
       SCOPE to authConfiguration.scope,
     )
 
@@ -181,7 +180,6 @@ constructor(
         val responseBody =
           oAuthService.logout(
             clientId = authConfiguration.clientId,
-            clientSecret = authConfiguration.clientSecret,
             refreshToken = accountManager.getPassword(account),
           )
 

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/app/AppConfigService.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/app/AppConfigService.kt
@@ -32,7 +32,6 @@ class AppConfigService @Inject constructor(@ApplicationContext val context: Cont
       fhirServerBaseUrl = "http://fake.base.url.com",
       oauthServerBaseUrl = "http://fake.keycloak.url.com",
       clientId = "fake-client-id",
-      clientSecret = "siri-fake",
       accountType = context.packageName,
     )
 

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/TokenAuthenticatorTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/TokenAuthenticatorTest.kt
@@ -303,8 +303,7 @@ class TokenAuthenticatorTest : RobolectricTest() {
     every { tokenAuthenticator.findAccount() } returns account
     every { accountManager.getPassword(account) } returns refreshToken
 
-    val refreshTokenSlot = slot<String>()
-    coEvery { oAuthService.logout(any(), any(), capture(refreshTokenSlot)) } returns
+    coEvery { oAuthService.logout(any(), any()) } returns
       Response.success(200, mockk<RealResponseBody>())
 
     every { accountManager.invalidateAuthToken(account.type, any()) } just runs
@@ -322,14 +321,14 @@ class TokenAuthenticatorTest : RobolectricTest() {
 
     val httpException = HttpException(Response.success(null))
 
-    coEvery { oAuthService.logout(any(), any(), any()) }.throws(httpException)
+    coEvery { oAuthService.logout(any(), any()) }.throws(httpException)
 
     var result = tokenAuthenticator.logout()
     Assert.assertEquals(Result.failure<HttpException>(httpException), result)
 
     val unknownHostException = UnknownHostException()
 
-    coEvery { oAuthService.logout(any(), any(), any()) }.throws(unknownHostException)
+    coEvery { oAuthService.logout(any(), any()) }.throws(unknownHostException)
 
     result = tokenAuthenticator.logout()
     Assert.assertEquals(Result.failure<UnknownHostException>(unknownHostException), result)

--- a/android/geowidget/src/test/java/org/smartregister/fhircore/geowidget/di/config/FakeConfigService.kt
+++ b/android/geowidget/src/test/java/org/smartregister/fhircore/geowidget/di/config/FakeConfigService.kt
@@ -30,7 +30,6 @@ class FakeConfigService @Inject constructor() : ConfigService {
       fhirServerBaseUrl = "https://fhir-server.com",
       oauthServerBaseUrl = "https://fhir-oauth-server.com/oauth",
       clientId = "client-id",
-      clientSecret = "client-secret",
       accountType = "account-type",
     )
   }

--- a/android/properties.gradle.kts
+++ b/android/properties.gradle.kts
@@ -24,7 +24,6 @@ val requiredFhirProperties =
     "FHIR_BASE_URL",
     "OAUTH_BASE_URL",
     "OAUTH_CLIENT_ID",
-    "OAUTH_CLIENT_SECRET",
     "OAUTH_SCOPE",
     "MAPBOX_SDK_TOKEN",
     "SENTRY_DSN"

--- a/android/quest/build.gradle.kts
+++ b/android/quest/build.gradle.kts
@@ -65,11 +65,6 @@ android {
     buildConfigField("String", "OAUTH_BASE_URL", """"${project.extra["OAUTH_BASE_URL"]}"""")
     buildConfigField("String", "OAUTH_CLIENT_ID", """"${project.extra["OAUTH_CLIENT_ID"]}"""")
     buildConfigField("String", "OAUTH_SCOPE", """"${project.extra["OAUTH_SCOPE"]}"""")
-    buildConfigField(
-      "String",
-      "OAUTH_CLIENT_SECRET",
-      """"${project.extra["OAUTH_CLIENT_SECRET"]}"""",
-    )
     buildConfigField("String", "CONFIGURATION_SYNC_PAGE_SIZE", """"100"""")
     buildConfigField("String", "SENTRY_DSN", """"${project.extra["SENTRY_DSN"]}"""")
 

--- a/android/quest/build.gradle.kts
+++ b/android/quest/build.gradle.kts
@@ -56,8 +56,8 @@ android {
     applicationId = "org.smartregister.opensrp"
     minSdk = 26
     targetSdk = 34
-    versionCode = 4
-    versionName = "1.0.0"
+    versionCode = 7
+    versionName = "1.0.1"
     multiDexEnabled = true
 
     buildConfigField("boolean", "SKIP_AUTH_CHECK", "false")

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/QuestConfigService.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/QuestConfigService.kt
@@ -35,7 +35,6 @@ class QuestConfigService @Inject constructor(@ApplicationContext val context: Co
       fhirServerBaseUrl = BuildConfig.FHIR_BASE_URL,
       oauthServerBaseUrl = BuildConfig.OAUTH_BASE_URL,
       clientId = BuildConfig.OAUTH_CLIENT_ID,
-      clientSecret = BuildConfig.OAUTH_CLIENT_SECRET,
       accountType = BuildConfig.APPLICATION_ID,
     )
 

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/QuestConfigServiceTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/QuestConfigServiceTest.kt
@@ -50,7 +50,6 @@ class QuestConfigServiceTest : RobolectricTest() {
     Assert.assertEquals(BuildConfig.FHIR_BASE_URL, authConfiguration.fhirServerBaseUrl)
     Assert.assertEquals(BuildConfig.OAUTH_BASE_URL, authConfiguration.oauthServerBaseUrl)
     Assert.assertEquals(BuildConfig.OAUTH_CLIENT_ID, authConfiguration.clientId)
-    Assert.assertEquals(BuildConfig.OAUTH_CLIENT_SECRET, authConfiguration.clientSecret)
     Assert.assertEquals(
       context.getString(R.string.authenticator_account_type),
       authConfiguration.accountType,

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/app/AppConfigService.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/app/AppConfigService.kt
@@ -32,7 +32,6 @@ class AppConfigService @Inject constructor(@ApplicationContext val context: Cont
       fhirServerBaseUrl = "http://fake.base.url.com",
       oauthServerBaseUrl = "http://fake.keycloak.url.com",
       clientId = "fake-client-id",
-      clientSecret = "siri-fake",
       accountType = context.packageName,
     )
 

--- a/docs/engineering/android-app/developer-setup/publishing-fhir-sdk-artifacts.mdx
+++ b/docs/engineering/android-app/developer-setup/publishing-fhir-sdk-artifacts.mdx
@@ -55,10 +55,10 @@ Building FHIR Core should now import the new artifact version. MavenLocal is alr
   4. _Update the versions_ of the various modules you want to publish in the `buildSrc/src/main/kotlin/Releases.kt` file
   5. _Make a commit_ with the updated versions and _add a commit message_ in the format shown in the [Commits section below](#commits)
   6. Push the commit to the `master-release` branch for tracking
-  7. Now that the `master-release` branch has all the latest updates from parent `master`, _Check out_ to a new branch on your local e.g. `opensrp-release1`
+  7. Now that the `master-release` branch has all the latest updates from parent `master`, _Check out_ to a new branch on your local with today's date in the dot separated double digit format **DD-MM-YY** and prefixe with `release-` e.g. `release-20.10.23`
   8. Merge in any other unmerged PR branches mentioned in the previous commit message and have not been merged to `master` yet
   9. _Publish_ the specific modules that you wanted. See the [Publishing section below](#publishing)
-  10. After a successful publish to Maven you can _Delete_ your release branch.
+  10. After a successful publish to Maven push your release branch above for versioning.
 
 **Note:** Always remember to check out the _commits diff_ to tell which modules were affected by the latest changes. You can confirm that your module artifact was uploaded as it is available at https://oss.sonatype.org/content/repositories/snapshots/org/smartregister/
 

--- a/docs/engineering/android-app/getting-started/readme.mdx
+++ b/docs/engineering/android-app/getting-started/readme.mdx
@@ -16,10 +16,9 @@ Begin by cloning this repository. Ensure you have JAVA 11 installed, and setup A
 Update `local.properties` file by providing the required Keycloak credentials to enable syncing of data to and from the HAPI FHIR server:
 
 ```
-#oauth credentials
+#oauth configurations
 OAUTH_BASE_URL=https://keycloak-stage.smartregister.org/auth/realms/FHIR_Android/
 OAUTH_CLIENT_ID="provide client id"
-OAUTH_CLIENT_SECRET="provide client secret"
 OAUTH_SCOPE=openid
 
 #fhir store base url
@@ -29,6 +28,8 @@ FHIR_BASE_URL=https://fhir.labs.smartregister.org/fhir/
 SENTRY_DSN=<https://your/sentry/project/dsn>
 
 ```
+
+**Note:** It is required to configure your OAuth client as **public** hence there's no need for a _OAuth client secret_.
 
 #### Gateway vs Non Gateway backend
 The codebase supports building a release that uses the [FHIR Gateway backend](https://github.com/opensrp/fhir-gateway) and one that doesn't. The **proxy** mode is the _default_ but if your backend is not using the [FHIR Gateway](https://github.com/opensrp/fhir-gateway/releases) you need to specify this by switching to the correct build type variant. To switch between the two one needs to change to a variant with the `debugNonProxy` build type. e.g for the flavor `opensrp` select the variant `opensrpDebugNonProxy`


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Closes https://github.com/onaio/fhir-resources/issues/2776

**Engineer Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [x] I have added any strings visible on UI components to the `strings.xml` file
- [x] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [x] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._

**NOTE** : It is required to configure your Keycloak OAuth client as **PUBLIC**. This way there's no need for a _OAuth client secret_. Authentication is secured by the user credentials


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
