### PR TITLE
[MWCore] Resume previous activity on login from background

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/QuestApplication.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/QuestApplication.kt
@@ -16,6 +16,7 @@
 
 package org.smartregister.fhircore.quest
 
+import android.accounts.AccountManager
 import android.app.Activity
 import android.app.Application
 import android.content.Context
@@ -41,7 +42,6 @@ import org.smartregister.fhircore.engine.ui.appsetting.AppSettingActivity
 import org.smartregister.fhircore.engine.ui.login.LoginActivity
 import org.smartregister.fhircore.engine.ui.questionnaire.QuestionnaireItemViewHolderFactoryMatchersProviderFactoryImpl
 import org.smartregister.fhircore.engine.util.extension.getActivity
-import org.smartregister.fhircore.engine.util.extension.launchActivityWithNoBackStackHistory
 import org.smartregister.fhircore.engine.util.extension.showToast
 import timber.log.Timber
 
@@ -147,9 +147,15 @@ class QuestApplication :
         name !in activitiesAccessWithoutAuth
       }
       ?.let {
-        mForegroundActivityContext
-          ?.getActivity()
-          ?.launchActivityWithNoBackStackHistory<LoginActivity>()
+        mForegroundActivityContext?.getActivity()?.run {
+          this.startActivity(
+            Intent(this, LoginActivity::class.java).apply {
+              accountAuthenticator.retrieveLastLoggedInUsername()?.takeIf { it.isNotBlank() }?.let {
+                putExtra(AccountManager.KEY_ACCOUNT_NAME, it)
+              }
+            }
+          )
+        }
       }
   }
 


### PR DESCRIPTION
Allow user to resume to previous activity on login when user comes back to the app, after leaving the app

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes [link to issue]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
