### PR TITLE
[Quest/Malawi Core] Android App : Disabled Auto-Sync Following Questionnaire Submission 

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/ui/questionnaire/QuestionnaireActivity.kt
@@ -369,7 +369,7 @@ open class QuestionnaireActivity : BaseMultiLanguageActivity(), View.OnClickList
     dismissSaveProcessing()
     if (result) {
       // Put Sync Here
-      syncBroadcaster.runSync()
+      /** Disabled sync after submitting a questionnaire [SyncBroadcaster.runSync] */
       postSaveSuccessful(questionnaireResponse, extras)
     } else {
       Timber.e("An error occurred during extraction")

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/register/PatientRegisterScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/patient/register/PatientRegisterScreen.kt
@@ -75,7 +75,7 @@ fun PatientRegisterScreen(
               ?.decodeResourceFromString<QuestionnaireResponse>()
           val patientId = questionnaireResponse?.subject?.extractId()
           if (patientId != null) {
-            patientRegisterViewModel.syncBroadcaster.runSync()
+            /** Disabled sync after creating a patient [PatientRegisterViewModel.syncBroadcaster] */
             patientRegisterViewModel.onEvent(
               PatientRegisterEvent.OpenProfile(patientId, navController)
             )


### PR DESCRIPTION

**Description**
The background sync worker has been observed to cause performance issues while the user is using the app, thus the user will manually sync the data when necessary. 

Fixes  https://github.com/ona-health/mwcore-fhir-resources/issues/173

**Engineer Checklist**
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
