### PR TITLE
[MWCore] Update refresh token to avoid reuse of stale refresh token

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/auth/AccountAuthenticator.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/auth/AccountAuthenticator.kt
@@ -83,7 +83,7 @@ constructor(
       if (!refreshToken.isNullOrEmpty()) {
         authToken =
           try {
-            tokenAuthenticator.refreshToken(refreshToken)
+            tokenAuthenticator.refreshToken(account, refreshToken)
           } catch (ex: Exception) {
             Timber.e(ex)
             "" // Set to EMPTY, so as to redirect to log in screen, and try again

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/data/remote/shared/TokenAuthenticator.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/data/remote/shared/TokenAuthenticator.kt
@@ -223,12 +223,15 @@ constructor(
    * [HttpException] or [UnknownHostException] exceptions
    */
   @Throws(HttpException::class, UnknownHostException::class)
-  fun refreshToken(currentRefreshToken: String): String {
+  fun refreshToken(account: Account, currentRefreshToken: String): String {
     return runBlocking {
       val oAuthResponse =
         oAuthService.fetchToken(
           buildOAuthPayload(REFRESH_TOKEN).apply { put(REFRESH_TOKEN, currentRefreshToken) }
         )
+
+      // Updates with new refresh-token
+      accountManager.setPassword(account, oAuthResponse.refreshToken!!)
 
       // Returns valid token or throws exception, NullPointerException not expected
       oAuthResponse.accessToken!!

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/AccountAuthenticatorTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/AccountAuthenticatorTest.kt
@@ -253,8 +253,9 @@ class AccountAuthenticatorTest : RobolectricTest() {
     every { accountManager.peekAuthToken(account, authTokenType) } returns ""
     val refreshToken = "refreshToken"
     every { accountManager.getPassword(account) } returns refreshToken
+    every { accountManager.setPassword(account, any()) } just runs
 
-    every { tokenAuthenticator.refreshToken(refreshToken) } returns ""
+    every { tokenAuthenticator.refreshToken(account, refreshToken) } returns ""
 
     val authToken = accountAuthenticator.getAuthToken(mockk(), account, authTokenType, bundleOf())
     val parcelable = authToken.get(AccountManager.KEY_INTENT) as Intent
@@ -273,7 +274,8 @@ class AccountAuthenticatorTest : RobolectricTest() {
 
     val refreshToken = "refreshToken"
     every { accountManager.getPassword(account) } returns refreshToken
-    every { tokenAuthenticator.refreshToken(refreshToken) } returns "newAccessToken"
+    every { accountManager.setPassword(account, any()) } just runs
+    every { tokenAuthenticator.refreshToken(account, refreshToken) } returns "newAccessToken"
 
     val authTokenBundle: Bundle =
       accountAuthenticator.getAuthToken(null, account, authTokenType, bundleOf())
@@ -291,7 +293,7 @@ class AccountAuthenticatorTest : RobolectricTest() {
 
     val refreshToken = "refreshToken"
     every { accountManager.getPassword(account) } returns refreshToken
-    every { tokenAuthenticator.refreshToken(refreshToken) } throws
+    every { tokenAuthenticator.refreshToken(account, refreshToken) } throws
       HttpException(
         mockk {
           every { code() } returns 0
@@ -314,7 +316,7 @@ class AccountAuthenticatorTest : RobolectricTest() {
 
     val refreshToken = "refreshToken"
     every { accountManager.getPassword(account) } returns refreshToken
-    every { tokenAuthenticator.refreshToken(refreshToken) } throws UnknownHostException()
+    every { tokenAuthenticator.refreshToken(account, refreshToken) } throws UnknownHostException()
 
     val authTokenBundle: Bundle =
       accountAuthenticator.getAuthToken(null, account, authTokenType, bundleOf())
@@ -330,7 +332,7 @@ class AccountAuthenticatorTest : RobolectricTest() {
 
     val refreshToken = "refreshToken"
     every { accountManager.getPassword(account) } returns refreshToken
-    every { tokenAuthenticator.refreshToken(refreshToken) } throws RuntimeException()
+    every { tokenAuthenticator.refreshToken(account, refreshToken) } throws RuntimeException()
 
     val authTokenBundle =
       accountAuthenticator.getAuthToken(null, account, authTokenType, bundleOf())

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/TokenAuthenticatorTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/auth/TokenAuthenticatorTest.kt
@@ -34,6 +34,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.verify
 import io.mockk.verifyOrder
 import java.io.IOException
 import java.net.UnknownHostException
@@ -388,6 +389,7 @@ class TokenAuthenticatorTest : RobolectricTest() {
 
   @Test
   fun testRefreshTokenShouldReturnToken() {
+    val account = Account(sampleUsername, PROVIDER)
     val accessToken = "soRefreshingNewToken"
     val oAuthResponse =
       OAuthResponse(
@@ -398,11 +400,13 @@ class TokenAuthenticatorTest : RobolectricTest() {
         scope = SCOPE
       )
     coEvery { oAuthService.fetchToken(any()) } returns oAuthResponse
+    every { accountManager.setPassword(account, any()) } just runs
 
     val currentRefreshToken = "oldRefreshToken"
-    val newAccessToken = tokenAuthenticator.refreshToken(currentRefreshToken)
+    val newAccessToken = tokenAuthenticator.refreshToken(account, currentRefreshToken)
     Assert.assertNotNull(newAccessToken)
     Assert.assertEquals(accessToken, newAccessToken)
+    verify { accountManager.setPassword(eq(account), oAuthResponse.refreshToken) }
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Stale refresh token on expiry leads to requests raising 401 and sync failing

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #2958 

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
