### PR TITLE
Clear text to re-generate it from SDK

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtension.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtension.kt
@@ -1,0 +1,19 @@
+package org.smartregister.fhircore.engine.util.extension
+
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
+
+/** Clears the item text in the [QuestionnaireResponse]. */
+fun QuestionnaireResponse.clearText() {
+    this.item.clearText()
+}
+
+/** Clears the text of items in the current list. */
+private fun List<QuestionnaireResponseItemComponent>.clearText() {
+    this.forEach { itemToClear ->
+        itemToClear.text = null
+        if (itemToClear.hasItem()) {
+            itemToClear.item.clearText()
+        }
+    }
+}

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtension.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtension.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.smartregister.fhircore.engine.util.extension
 
 import org.hl7.fhir.r4.model.QuestionnaireResponse
@@ -5,15 +21,15 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComp
 
 /** Clears the item text in the [QuestionnaireResponse]. */
 fun QuestionnaireResponse.clearText() {
-    this.item.clearText()
+  this.item.clearText()
 }
 
 /** Clears the text of items in the current list. */
 private fun List<QuestionnaireResponseItemComponent>.clearText() {
-    this.forEach { itemToClear ->
-        itemToClear.text = null
-        if (itemToClear.hasItem()) {
-            itemToClear.item.clearText()
-        }
+  this.forEach { itemToClear ->
+    itemToClear.text = null
+    if (itemToClear.hasItem()) {
+      itemToClear.item.clearText()
     }
+  }
 }

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtensionTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtensionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Ona Systems, Inc
+ * Copyright 2021-2024 Ona Systems, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,16 +26,17 @@ class QuestionnaireResponseExtensionTest {
 
   @Before
   fun setup() {
-    questionnaireResponse = QuestionnaireResponse().apply {
-      addItem().apply {
-        linkId = "1"
-        text = "Text 1"
+    questionnaireResponse =
+      QuestionnaireResponse().apply {
         addItem().apply {
-          linkId = "2"
-          text = "Text 2"
+          linkId = "1"
+          text = "Text 1"
+          addItem().apply {
+            linkId = "2"
+            text = "Text 2"
+          }
         }
       }
-    }
   }
 
   @Test

--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtensionTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/util/extension/QuestionnaireResponseExtensionTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021-2023 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.engine.util.extension
+
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class QuestionnaireResponseExtensionTest {
+  private lateinit var questionnaireResponse: QuestionnaireResponse
+
+  @Before
+  fun setup() {
+    questionnaireResponse = QuestionnaireResponse().apply {
+      addItem().apply {
+        linkId = "1"
+        text = "Text 1"
+        addItem().apply {
+          linkId = "2"
+          text = "Text 2"
+        }
+      }
+    }
+  }
+
+  @Test
+  fun testClearText() {
+    questionnaireResponse.clearText()
+    val item1 = questionnaireResponse.itemFirstRep
+    Assert.assertNull(item1.text)
+    val item2 = item1.itemFirstRep
+    Assert.assertNull(item2.text)
+  }
+}

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
@@ -206,8 +206,8 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
         val questionnaireResponse =
           QuestionnaireResponse().apply {
             item = latestQuestionnaireResponse?.item
-            clearText() // Clearing the text prompts the SDK to re-process the content, which
-            // include HTMLs
+            // Clearing the text prompts the SDK to re-process the content, which includes HTML
+            clearText()
           }
 
         if (viewModel.validateQuestionnaireResponse(questionnaire, questionnaireResponse, this)) {

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
@@ -207,7 +207,7 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
           QuestionnaireResponse().apply {
             item = latestQuestionnaireResponse?.item
             clearText() // Clearing the text prompts the SDK to re-process the content, which
-                        // include HTMLs
+            // include HTMLs
           }
 
         if (viewModel.validateQuestionnaireResponse(questionnaire, questionnaireResponse, this)) {

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
@@ -44,6 +44,7 @@ import org.smartregister.fhircore.engine.domain.model.isEditable
 import org.smartregister.fhircore.engine.domain.model.isReadOnly
 import org.smartregister.fhircore.engine.ui.base.AlertDialogue
 import org.smartregister.fhircore.engine.ui.base.BaseMultiLanguageActivity
+import org.smartregister.fhircore.engine.util.extension.clearText
 import org.smartregister.fhircore.engine.util.extension.encodeResourceToString
 import org.smartregister.fhircore.engine.util.extension.parcelable
 import org.smartregister.fhircore.engine.util.extension.parcelableArrayList
@@ -203,7 +204,10 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
           )
 
         val questionnaireResponse =
-          QuestionnaireResponse().apply { item = latestQuestionnaireResponse?.item }
+          QuestionnaireResponse().apply {
+            item = latestQuestionnaireResponse?.item
+            clearText() // Clearing the text prompts the SDK to re-process the content, which include HTMLs
+          }
 
         if (viewModel.validateQuestionnaireResponse(questionnaire, questionnaireResponse, this)) {
           questionnaireFragmentBuilder.setQuestionnaireResponse(questionnaireResponse.json())

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
@@ -206,7 +206,8 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
         val questionnaireResponse =
           QuestionnaireResponse().apply {
             item = latestQuestionnaireResponse?.item
-            clearText() // Clearing the text prompts the SDK to re-process the content, which include HTMLs
+            clearText() // Clearing the text prompts the SDK to re-process the content, which
+                        // include HTMLs
           }
 
         if (viewModel.validateQuestionnaireResponse(questionnaire, questionnaireResponse, this)) {


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #2994 

Clear text from QuestionnaireResponse, so that the SDK (SDC [QuestionnaireViewModel](https://github.com/google/android-fhir/blob/master/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt#L862)) will re-generate a new text with HTML.

**Engineer Checklist**
- [x] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [x] I have added any strings visible on UI components to the `strings.xml` file
- [x] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [x] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [x] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
