### PR TITLE
Skip creation of local change entities for composition and config resources during sync down

### DIFF
--- a/android/engine/src/test/java/org/smartregister/fhircore/engine/configuration/ConfigurationRegistryTest.kt
+++ b/android/engine/src/test/java/org/smartregister/fhircore/engine/configuration/ConfigurationRegistryTest.kt
@@ -43,7 +43,6 @@ import org.hl7.fhir.r4.model.Composition.SectionComponent
 import org.hl7.fhir.r4.model.Enumerations
 import org.hl7.fhir.r4.model.Group
 import org.hl7.fhir.r4.model.Identifier
-import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
@@ -310,7 +309,7 @@ class ConfigurationRegistryTest : RobolectricTest() {
     coEvery { fhirEngine.createRemote(patient) } just runs
 
     runTest {
-      configRegistry.create(patient)
+      configRegistry.createRemote(patient)
       coVerify { fhirEngine.createRemote(patient) }
     }
   }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/ConfigDownloadWorker.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/ConfigDownloadWorker.kt
@@ -48,7 +48,7 @@ constructor(
       try {
         // Save composition after fetching all the referenced section resources
         configurationRegistry.fetchNonWorkflowConfigResources(isInitialLogin)?.run {
-          defaultRepository.createRemote(false, this)
+          configurationRegistry.addOrUpdate(this)
         }
         dataMigration.migrate()
         Result.success()

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/app/ConfigurationRegistryTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/app/ConfigurationRegistryTest.kt
@@ -109,7 +109,7 @@ class ConfigurationRegistryTest : RobolectricTest() {
 
     configurationRegistry.fetchNonWorkflowConfigResources()
     coVerify { configurationRegistry.fhirResourceDataSource.getResource(any()) }
-    coVerify { configurationRegistry.create(any()) }
+    coVerify { configurationRegistry.createRemote(any()) }
   }
 
   @Test
@@ -141,6 +141,6 @@ class ConfigurationRegistryTest : RobolectricTest() {
 
     configurationRegistry.fetchNonWorkflowConfigResources()
     coVerify { configurationRegistry.fhirResourceDataSource.getResource(any()) }
-    coVerify { configurationRegistry.create(any()) }
+    coVerify { configurationRegistry.createRemote(any()) }
   }
 }


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes [link to issue]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
