### PR TITLE
Make app title visibility configurable in LoginScreen

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/LoginConfig.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/app/LoginConfig.kt
@@ -26,4 +26,5 @@ data class LoginConfig(
   val pinLoginMessage: String? = null,
   val logoHeight: Int = 120,
   val logoWidth: Int = 140,
+  val showAppTitle: Boolean = true,
 )

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/LoginScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/login/LoginScreen.kt
@@ -192,7 +192,7 @@ fun LoginPage(
                 .testTag(APP_LOGO_TAG),
           )
         }
-        if (applicationConfiguration.appTitle.isNotEmpty()) {
+        if (applicationConfiguration.appTitle.isNotEmpty() && applicationConfiguration.loginConfig.showAppTitle) {
           Text(
             color = if (applicationConfiguration.useDarkTheme) Color.White else LoginDarkColor,
             text = applicationConfiguration.appTitle,


### PR DESCRIPTION
This PR will make app title visibility configurable in LoginScreen. This is something that was required for the mockup mentioned in this [ticket](https://github.com/onaio/fhir-resources/issues/2957)


**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
