### PR TITLE
Fix read-only linkIds for questionnaires in Edit mode

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/ResourceExtension.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/extension/ResourceExtension.kt
@@ -199,7 +199,7 @@ fun List<Questionnaire.QuestionnaireItemComponent>.generateMissingItems(
  */
 fun List<Questionnaire.QuestionnaireItemComponent>.prepareQuestionsForReadingOrEditing(
   path: String = "QuestionnaireResponse.item",
-  readOnly: Boolean = false,
+  readOnly: Boolean,
   readOnlyLinkIds: List<String>? = emptyList(),
 ) {
   forEach { item ->

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -145,7 +145,7 @@ constructor(
       defaultRepository.loadResource<Questionnaire>(questionnaireConfig.id)?.apply {
         if (questionnaireConfig.isReadOnly() || questionnaireConfig.isEditable()) {
           item.prepareQuestionsForReadingOrEditing(
-            readOnly = questionnaireConfig.isReadOnly(),
+            readOnly = questionnaireConfig.isReadOnly() || questionnaireConfig.isEditable(),
             readOnlyLinkIds = questionnaireConfig.readOnlyLinkIds,
           )
         }


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes [link to issue]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
