### PR TITLE
[Opensrp 0.2.5] Fix build errors caused by deprecated repositories

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -28,7 +28,8 @@ allprojects {
     google()
     mavenCentral()
     maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
-    maven(url = "https://jcenter.bintray.com/")
+    maven(url = "https://repo.spring.io/plugins-release")
+    maven(url = "https://repository.liferay.com/nexus/content/repositories/public")
   }
 }
 


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes/Replaces deprecated dependency repositories
 
