### PR TITLE
Add configurable content padding to change size of actionable button

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/view/ButtonProperties.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/configuration/view/ButtonProperties.kt
@@ -56,6 +56,8 @@ data class ButtonProperties(
   val backgroundOpacity: Float = 0f,
   val colorOpacity: Float = 0f,
   val statusIconSize: Int = 16,
+  val contentPaddingVertical: Float? = null,
+  val contentPaddingHorizontal: Float? = null,
 ) : ViewProperties(), Parcelable {
   /**
    * This function determines the status color to display depending on the value of the service

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/components/ActionableButton.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/shared/components/ActionableButton.kt
@@ -138,12 +138,29 @@ fun ActionableButton(
       enabled = buttonProperties.enabled.toBoolean(),
       border = BorderStroke(width = 0.8.dp, color = statusColor.copy(alpha = 0.1f)),
       elevation = null,
-      contentPadding =
-        if (buttonProperties.buttonType == ButtonType.TINY) {
-          PaddingValues(vertical = 2.4.dp, horizontal = 4.dp)
+      contentPadding = run {
+        // Determine default padding based on button type
+        val defaultPadding: PaddingValues = when (buttonProperties.buttonType) {
+          ButtonType.TINY -> PaddingValues(vertical = 2.4.dp, horizontal = 4.dp)
+          else -> PaddingValues(vertical = 4.8.dp, horizontal = 8.dp)
+        }
+
+        // Check if custom padding values are provided
+        val customPadding: PaddingValues? = if (
+          buttonProperties.contentPaddingHorizontal != null &&
+          buttonProperties.contentPaddingVertical != null
+        ) {
+          PaddingValues(
+            vertical = buttonProperties.contentPaddingVertical!!.dp,
+            horizontal = buttonProperties.contentPaddingHorizontal!!.dp
+          )
         } else {
-          PaddingValues(vertical = 4.8.dp, horizontal = 8.dp)
-        },
+          null
+        }
+
+        // Use custom padding if available; otherwise, fallback to default padding
+        customPadding ?: defaultPadding
+      },
       shape = RoundedCornerShape(buttonProperties.borderRadius),
     ) {
       // Each component here uses a new modifier to avoid inheriting the properties of the


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

- Actionable button width and height is not configurable to a specific size
- Adding the contentPaddingVertical and contentPaddingHorizontal will apply padding to the actionable button, which then increase it's size

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
