### PR TITLE
Fix save as draft will not save for QR with nested answer

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -79,6 +79,7 @@ import org.smartregister.fhircore.engine.task.FhirCarePlanGenerator
 import org.smartregister.fhircore.engine.util.DispatcherProvider
 import org.smartregister.fhircore.engine.util.SharedPreferenceKey
 import org.smartregister.fhircore.engine.util.SharedPreferencesHelper
+import org.smartregister.fhircore.engine.util.extension.allItems
 import org.smartregister.fhircore.engine.util.extension.appendOrganizationInfo
 import org.smartregister.fhircore.engine.util.extension.appendPractitionerInfo
 import org.smartregister.fhircore.engine.util.extension.appendRelatedEntityLocation
@@ -711,19 +712,7 @@ constructor(
     questionnaireResponse: QuestionnaireResponse,
     questionnaireConfig: QuestionnaireConfig,
   ) {
-    val hasPages = questionnaireResponse.item.any { it.hasItem() }
-    val questionnaireHasAnswer =
-      questionnaireResponse.item.any {
-        if (!hasPages) {
-          it.answer.any { answerComponent -> answerComponent.hasValue() }
-        } else {
-          questionnaireResponse.item.any { page ->
-            page.item.any { pageItem ->
-              pageItem.answer.any { answerComponent -> answerComponent.hasValue() }
-            }
-          }
-        }
-      }
+    val hasAnswer = questionnaireResponse.allItems.any { it.hasAnswer() }
     questionnaireResponse.questionnaire =
       questionnaireConfig.id.asReference(ResourceType.Questionnaire).reference
     if (
@@ -735,7 +724,7 @@ constructor(
           questionnaireConfig.resourceType!!,
         )
     }
-    if (questionnaireHasAnswer) {
+    if (hasAnswer) {
       questionnaireResponse.status = QuestionnaireResponse.QuestionnaireResponseStatus.INPROGRESS
       defaultRepository.addOrUpdate(
         addMandatoryTags = true,


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Save as draft has a validation to check if the QR to be saved has answer or not. That validation does not work for QR that has answers that are nested within child items. The validation should flatten the items before checking the answers.

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
