### PR TITLE
Make Pin Log in screen logo size configurable

### DIFF
--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/pin/PinLoginScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/pin/PinLoginScreen.kt
@@ -152,7 +152,7 @@ fun PinLoginPage(
             PinLogoSection(
               showLogo = pinUiState.showLogo,
               title = pinUiState.appName,
-              applicationConfiguration = applicationConfiguration
+              applicationConfiguration = applicationConfiguration,
             )
           }
           Text(
@@ -240,7 +240,7 @@ private fun PinLogoSection(
   modifier: Modifier = Modifier,
   showLogo: Boolean,
   title: String,
-  applicationConfiguration: ApplicationConfiguration
+  applicationConfiguration: ApplicationConfiguration,
 ) {
   Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier.fillMaxWidth()) {
     if (showLogo) {

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/pin/PinLoginScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/pin/PinLoginScreen.kt
@@ -146,10 +146,14 @@ fun PinLoginPage(
             PinLogoSection(
               showLogo = pinUiState.showLogo,
               title = stringResource(id = R.string.set_pin),
-              applicationConfiguration = applicationConfiguration
+              applicationConfiguration = applicationConfiguration,
             )
           } else {
-            PinLogoSection(showLogo = pinUiState.showLogo, title = pinUiState.appName, applicationConfiguration = applicationConfiguration)
+            PinLogoSection(
+              showLogo = pinUiState.showLogo,
+              title = pinUiState.appName,
+              applicationConfiguration = applicationConfiguration
+            )
           }
           Text(
             text = pinUiState.message,
@@ -232,7 +236,12 @@ fun PinLoginPage(
 }
 
 @Composable
-private fun PinLogoSection(modifier: Modifier = Modifier, showLogo: Boolean, title: String, applicationConfiguration: ApplicationConfiguration) {
+private fun PinLogoSection(
+  modifier: Modifier = Modifier,
+  showLogo: Boolean,
+  title: String,
+  applicationConfiguration: ApplicationConfiguration
+) {
   Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier.fillMaxWidth()) {
     if (showLogo) {
       Image(

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/pin/PinLoginScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/pin/PinLoginScreen.kt
@@ -146,9 +146,10 @@ fun PinLoginPage(
             PinLogoSection(
               showLogo = pinUiState.showLogo,
               title = stringResource(id = R.string.set_pin),
+              applicationConfiguration = applicationConfiguration
             )
           } else {
-            PinLogoSection(showLogo = pinUiState.showLogo, title = pinUiState.appName)
+            PinLogoSection(showLogo = pinUiState.showLogo, title = pinUiState.appName, applicationConfiguration = applicationConfiguration)
           }
           Text(
             text = pinUiState.message,
@@ -231,7 +232,7 @@ fun PinLoginPage(
 }
 
 @Composable
-private fun PinLogoSection(modifier: Modifier = Modifier, showLogo: Boolean, title: String) {
+private fun PinLogoSection(modifier: Modifier = Modifier, showLogo: Boolean, title: String, applicationConfiguration: ApplicationConfiguration) {
   Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier.fillMaxWidth()) {
     if (showLogo) {
       Image(
@@ -240,8 +241,8 @@ private fun PinLogoSection(modifier: Modifier = Modifier, showLogo: Boolean, tit
         modifier =
           modifier
             .align(Alignment.CenterHorizontally)
-            .requiredHeight(120.dp)
-            .requiredWidth(140.dp)
+            .requiredHeight(applicationConfiguration.loginConfig.logoHeight.dp)
+            .requiredWidth(applicationConfiguration.loginConfig.logoWidth.dp)
             .testTag(PIN_LOGO_IMAGE),
       )
     }


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

In the current implementation the height and width of the App Logo in the Pin Log in screen are hardcoded. This PR provides configurability for the values. 

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
